### PR TITLE
feat: add generic information layer for push-based data delivery

### DIFF
--- a/ptt-box/stream_client/index.html
+++ b/ptt-box/stream_client/index.html
@@ -807,6 +807,60 @@
             background: #5c5f7e;
             color: #fff;
         }
+        /* Information Toast */
+        .info-toast-container {
+            position: fixed;
+            top: 10px;
+            right: 10px;
+            z-index: 900;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            max-width: 320px;
+            pointer-events: none;
+        }
+        .info-toast {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            padding: 12px 14px;
+            background: rgba(22, 33, 62, 0.92);
+            backdrop-filter: blur(8px);
+            border: 1px solid rgba(255, 255, 255, 0.1);
+            border-radius: 10px;
+            color: #eee;
+            font-size: 13px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+            opacity: 0;
+            transform: translateX(40px);
+            transition: opacity 0.3s, transform 0.3s;
+            pointer-events: auto;
+        }
+        .info-toast.show {
+            opacity: 1;
+            transform: translateX(0);
+        }
+        .info-toast.fade-out {
+            opacity: 0;
+            transform: translateX(40px);
+        }
+        .info-toast-icon {
+            font-size: 20px;
+            flex-shrink: 0;
+            margin-top: 1px;
+        }
+        .info-toast-body {
+            flex: 1;
+            min-width: 0;
+        }
+        .info-toast-title {
+            font-weight: 600;
+            margin-bottom: 2px;
+        }
+        .info-toast-text {
+            color: #bbb;
+            word-break: break-word;
+        }
     </style>
 </head>
 <body>
@@ -1072,6 +1126,7 @@
     <script src="js/stream.js"></script>
     <script src="js/history.js"></script>
     <script src="js/assistant.js"></script>
+    <script src="js/info.js"></script>
     <script>
         // Service Worker登録
         if ('serviceWorker' in navigator) {

--- a/ptt-box/stream_client/js/info.js
+++ b/ptt-box/stream_client/js/info.js
@@ -1,0 +1,67 @@
+// 汎用インフォメーション通知
+
+const INFO_TOAST_DURATION = 5000;
+const INFO_TOAST_MAX = 3;
+
+const INFO_ICONS = {
+    sensor: '\u{1F4E1}', alert: '\u26A0\uFE0F', announce: '\u{1F4E2}',
+    system: '\u2699\uFE0F', default: '\u2139\uFE0F'
+};
+
+function handleInformation(data) {
+    showInfoToast(data);
+}
+
+async function fetchLatestInformation() {
+    try {
+        const res = await fetch('/api/information/latest');
+        if (!res.ok) return;
+        const { items } = await res.json();
+        for (const data of Object.values(items)) {
+            showInfoToast(data);
+        }
+    } catch (e) {
+        console.log('Failed to fetch information:', e.message);
+    }
+}
+
+function showInfoToast(info) {
+    let container = document.getElementById('infoToastContainer');
+    if (!container) {
+        container = document.createElement('div');
+        container.id = 'infoToastContainer';
+        container.className = 'info-toast-container';
+        document.body.appendChild(container);
+    }
+    while (container.children.length >= INFO_TOAST_MAX) {
+        container.removeChild(container.firstChild);
+    }
+
+    const icon = INFO_ICONS[info.category] || INFO_ICONS.default;
+    const title = info.label || info.category;
+    const body = info.message || JSON.stringify(info.value ?? '');
+
+    const toast = document.createElement('div');
+    toast.className = 'info-toast';
+    toast.innerHTML =
+        '<span class="info-toast-icon">' + icon + '</span>' +
+        '<div class="info-toast-body">' +
+            '<div class="info-toast-title">' + escapeInfoHtml(title) + '</div>' +
+            '<div class="info-toast-text">' + escapeInfoHtml(body) + '</div>' +
+        '</div>';
+    container.appendChild(toast);
+    requestAnimationFrame(() => toast.classList.add('show'));
+
+    setTimeout(() => {
+        toast.classList.add('fade-out');
+        toast.addEventListener('transitionend', () => {
+            if (toast.parentNode) toast.parentNode.removeChild(toast);
+        });
+    }, INFO_TOAST_DURATION);
+}
+
+function escapeInfoHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}

--- a/ptt-box/stream_client/js/stream.js
+++ b/ptt-box/stream_client/js/stream.js
@@ -415,6 +415,11 @@ async function connect() {
                 if (vapidPublicKey) {
                     setupPushNotifications();
                 }
+
+                // 最新インフォメーション取得
+                setTimeout(() => {
+                    if (typeof fetchLatestInformation === 'function') fetchLatestInformation();
+                }, 2000);
             } else if (data.type === 'answer') {
                 debugLog('Received answer, applying remote description');
                 await pc.setRemoteDescription(new RTCSessionDescription({
@@ -498,6 +503,8 @@ async function connect() {
             } else if (data.type === 'health_status') {
                 // サービスヘルス状態更新
                 updateServiceStatus(data.services);
+            } else if (data.type === 'information') {
+                if (typeof handleInformation === 'function') handleInformation(data);
             }
             // AI Assistant messages (handled by assistant.js)
             else if (typeof processAIMessage === 'function') {

--- a/ptt-box/stream_client/sw.js
+++ b/ptt-box/stream_client/sw.js
@@ -1,11 +1,12 @@
 // Service Worker for Webトランシーバー PWA
 
-const CACHE_NAME = 'ptt-cache-v1';
+const CACHE_NAME = 'ptt-cache-v2';
 const ASSETS_TO_CACHE = [
     '/',
     '/index.html',
     '/js/stream.js',
     '/js/history.js',
+    '/js/info.js',
     '/manifest.json',
     '/icons/icon-192.png',
     '/icons/icon-512.png'

--- a/ptt-box/stream_server/server.js
+++ b/ptt-box/stream_server/server.js
@@ -284,6 +284,9 @@ class StreamServer {
         // サービスヘルス監視
         this.serviceHealth = new Map();  // serviceName -> { lastSeen: timestamp, status: 'up'|'down'|'unknown' }
 
+        // インフォメーション最新値キャッシュ
+        this.infoLatest = new Map();  // key -> { category, key, ...payload, timestamp }
+
         // Express設定
         this.app = express();
         this.server = http.createServer(this.app);
@@ -302,6 +305,9 @@ class StreamServer {
 
         // サービスヘルスAPI設定
         this.setupHealthApi();
+
+        // インフォメーションAPI設定
+        this.setupInformationApi();
 
         // History API設定
         this.setupHistoryApi();
@@ -583,6 +589,50 @@ class StreamServer {
             type: 'health_status',
             services: status
         };
+        for (const client of this.clients.values()) {
+            client.send(msg);
+        }
+    }
+
+    // 汎用インフォメーションAPI設定
+    setupInformationApi() {
+        // POST /api/information - 汎用情報受信
+        this.app.post('/api/information', (req, res) => {
+            const { category, key, ...rest } = req.body;
+            if (!category || typeof category !== 'string')
+                return res.status(400).json({ error: 'category is required' });
+
+            const infoKey = key || category;  // keyが無ければcategoryをキーに
+            this.ingestInformation({
+                category,
+                key: infoKey,
+                ...rest,
+                timestamp: rest.timestamp || new Date().toISOString()
+            });
+            res.json({ success: true });
+        });
+
+        // GET /api/information/latest - 最新値一覧
+        this.app.get('/api/information/latest', (req, res) => {
+            const items = {};
+            for (const [k, v] of this.infoLatest) items[k] = v;
+            res.json({ items });
+        });
+    }
+
+    ingestInformation(payload) {
+        this.infoLatest.set(payload.key, payload);
+        // メモリ制限: 最大100件
+        if (this.infoLatest.size > 100) {
+            const oldest = this.infoLatest.keys().next().value;
+            this.infoLatest.delete(oldest);
+        }
+        this.broadcastInformation(payload);
+        log(`[Info] ${payload.category}/${payload.key}: ${JSON.stringify(payload).substring(0, 100)}`);
+    }
+
+    broadcastInformation(payload) {
+        const msg = { type: 'information', ...payload };
         for (const client of this.clients.values()) {
             client.send(msg);
         }


### PR DESCRIPTION
## Summary

Closes #8

- Add REST API (`POST /api/information`, `GET /api/information/latest`) for ingesting and querying arbitrary data
- Broadcast received data to all connected WebSocket clients in real-time
- Display toast notifications (slide-in, auto-dismiss) on client side with category icons
- Fetch latest values on reconnect so clients stay up to date

## Test plan

- [ ] `curl -X POST` でデータ投入 → 接続中クライアントにトースト表示
- [ ] 複数カテゴリ (announce, sensor, alert) でアイコンが正しく表示される
- [ ] 5秒後にトーストがフェードアウトで消える
- [ ] `GET /api/information/latest` で投入済みデータが返る
- [ ] ブラウザリロード後、最新値がトースト表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)