### PR TITLE
fix: remove SessionSettings(limit=50) that broke tool call pairs

### DIFF
--- a/ptt-box/.env.example
+++ b/ptt-box/.env.example
@@ -92,8 +92,6 @@ ASSISTANT_SESSION_TIMEOUT=300
 AGENT_MAX_TURNS=10
 # セッションDBパス
 AGENT_SESSION_DB=./sessions.db
-# セッション履歴の最大件数 (古い履歴を自動的に切り捨て)
-AGENT_SESSION_HISTORY_LIMIT=50
 # ツール出力の切り詰め閾値（文字数。これを超える古いターンの出力を切り詰め）
 AGENT_TOOL_OUTPUT_MAX_CHARS=3000
 # 切り詰め時に残すプレビュー文字数

--- a/ptt-box/ai_assistant_agent.py
+++ b/ptt-box/ai_assistant_agent.py
@@ -83,7 +83,6 @@ MCP_CONFIG_PATH = Path(os.environ.get("MCP_CONFIG_PATH", Path(__file__).parent /
 # Agent SDK設定
 MAX_TURNS = int(os.environ.get("AGENT_MAX_TURNS", "10"))
 SESSION_DB_PATH = Path(os.environ.get("AGENT_SESSION_DB", Path(__file__).parent / "sessions.db"))
-SESSION_HISTORY_LIMIT = int(os.environ.get("AGENT_SESSION_HISTORY_LIMIT", "50"))
 TOOL_OUTPUT_MAX_CHARS = int(os.environ.get("AGENT_TOOL_OUTPUT_MAX_CHARS", "3000"))
 TOOL_OUTPUT_PREVIEW_CHARS = int(os.environ.get("AGENT_TOOL_OUTPUT_PREVIEW_CHARS", "500"))
 
@@ -367,16 +366,12 @@ def create_run_config():
     """セッション肥大化対策用のRunConfigを生成"""
     from agents import RunConfig
     from agents.extensions import ToolOutputTrimmer
-    from agents.memory import SessionSettings
 
     return RunConfig(
         call_model_input_filter=ToolOutputTrimmer(
             recent_turns=2,
             max_output_chars=TOOL_OUTPUT_MAX_CHARS,
             preview_chars=TOOL_OUTPUT_PREVIEW_CHARS,
-        ),
-        session_settings=SessionSettings(
-            limit=SESSION_HISTORY_LIMIT,
         ),
     )
 


### PR DESCRIPTION
## Summary
- `SessionSettings(limit=50)` が単純な行数LIMITでセッション履歴を切り詰めるため、`function_call` / `function_call_output` ペアが分断されAPIエラーが発生していた
- `No tool call found for function call output with call_id` エラーの原因を修正
- 残る2層の防御（ToolOutputTrimmer + エラー時自動復帰）でセッション肥大化は引き続き防止

## Test plan
- [x] サーバーテスト通過 (60/60)
- [x] `session_settings` が `None` であることを確認
- [x] 実機テストで再現しないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)