### PR TITLE
fix: add auto-recovery for orphaned function_call_output errors

### DIFF
--- a/ptt-box/ai_assistant_agent.py
+++ b/ptt-box/ai_assistant_agent.py
@@ -507,6 +507,7 @@ class AgentAssistant:
             if any(kw in error_str for kw in [
                 "context_length_exceeded", "maximum context length",
                 "context window", "too many tokens", "request too large",
+                "no tool call found",
             ]):
                 log("コンテキストウィンドウ超過を検出、セッションをクリアします", level="warning")
                 try:
@@ -607,6 +608,7 @@ class AgentAssistant:
             if any(kw in error_str for kw in [
                 "context_length_exceeded", "maximum context length",
                 "context window", "too many tokens", "request too large",
+                "no tool call found",
             ]):
                 log("コンテキストウィンドウ超過を検出、セッションをクリアします", level="warning")
                 try:


### PR DESCRIPTION
## Summary
- 孤立した `function_call_output` による `No tool call found` エラー発生時に、セッション自動クリアで復帰するよう対応
- `process_query()` と `process_query_streamed()` の2箇所にキーワード追加

## Test plan
- [x] Node.js テスト全60件パス (`npm test`)
- [x] Python 構文チェック OK

Refs #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)