### PR TITLE
fix: strip markdown table symbols from TTS text cleaning

### DIFF
--- a/ptt-box/ai_assistant.py
+++ b/ptt-box/ai_assistant.py
@@ -391,6 +391,10 @@ def clean_text_for_tts(text: str) -> str:
     text = re.sub(r'^\s*\d+\.\s+', '', text, flags=re.MULTILINE)
     # インラインコード (`code` → code)
     text = re.sub(r'`([^`]+)`', r'\1', text)
+    # マークダウンテーブル区切り線 (|---|---|)
+    text = re.sub(r'^\s*\|?[\s\-:]+(\|[\s\-:]+)+\|?\s*$', '', text, flags=re.MULTILINE)
+    # テーブルのパイプ記号
+    text = re.sub(r'\|', ' ', text)
     # 連続空白を整理
     text = re.sub(r'  +', ' ', text)
     return text.strip()

--- a/ptt-box/ai_assistant_agent.py
+++ b/ptt-box/ai_assistant_agent.py
@@ -642,6 +642,10 @@ def clean_text_for_tts(text: str) -> str:
     text = re.sub(r'^\s*\d+\.\s+', '', text, flags=re.MULTILINE)
     # インラインコード (`code` → code)
     text = re.sub(r'`([^`]+)`', r'\1', text)
+    # マークダウンテーブル区切り線 (|---|---|)
+    text = re.sub(r'^\s*\|?[\s\-:]+(\|[\s\-:]+)+\|?\s*$', '', text, flags=re.MULTILINE)
+    # テーブルのパイプ記号
+    text = re.sub(r'\|', ' ', text)
     # 連続空白を整理
     text = re.sub(r'  +', ' ', text)
     return text.strip()

--- a/ptt-box/stream_client/js/assistant.js
+++ b/ptt-box/stream_client/js/assistant.js
@@ -503,6 +503,10 @@ function cleanTextForTTS(text) {
     text = text.replace(/^\s*\d+\.\s+/gm, '');
     // インラインコード (`code` → code)
     text = text.replace(/`([^`]+)`/g, '$1');
+    // マークダウンテーブル区切り線 (|---|---|)
+    text = text.replace(/^\s*\|?[\s\-:]+(\|[\s\-:]+)+\|?\s*$/gm, '');
+    // テーブルのパイプ記号
+    text = text.replace(/\|/g, ' ');
     // 連続空白を整理
     text = text.replace(/ {2,}/g, ' ');
     return text.trim();


### PR DESCRIPTION
## Summary
- TTS読み上げ時にマークダウンテーブルのパイプ文字 `|` や区切り線 `|---|---|` が発声される問題を修正
- 3ファイルの `clean_text_for_tts()` にテーブル記号フィルタを追加

Closes #17