### PR TITLE
fix: TTS table symbol cleanup and P2P offer crash prevention

### DIFF
--- a/ptt-box/stream_server/server.js
+++ b/ptt-box/stream_server/server.js
@@ -2403,19 +2403,32 @@ class StreamServer {
         connInfo.audioTrack = audioTrack;
         p2pPc.addTrack(audioTrack);
 
-        // Offer作成
-        const offer = await p2pPc.createOffer();
-        await p2pPc.setLocalDescription(offer);
+        // Offer作成（非同期中にPCがclose/cleanupされる可能性があるためtry-catch）
+        try {
+            const offer = await p2pPc.createOffer();
 
-        // ICE gathering待機
-        await this.waitForIceGathering(p2pPc);
+            // createOffer中にPCがcloseされた場合を検出
+            if (p2pPc.connectionState === 'closed' || !this.p2pConnections.has(client.clientId)) {
+                log(`P2P to ${client.displayName}: connection closed during offer creation, aborting`);
+                return;
+            }
 
-        // Offer送信
-        client.send({
-            type: 'p2p_offer',
-            from: this.serverClientId,
-            sdp: p2pPc.localDescription.sdp
-        });
+            await p2pPc.setLocalDescription(offer);
+
+            // ICE gathering待機
+            await this.waitForIceGathering(p2pPc);
+
+            // Offer送信
+            client.send({
+                type: 'p2p_offer',
+                from: this.serverClientId,
+                sdp: p2pPc.localDescription.sdp
+            });
+        } catch (e) {
+            log(`P2P to ${client.displayName}: offer failed (${e.message}), cleaning up`);
+            try { p2pPc.close(); } catch (_) {}
+            this.p2pConnections.delete(client.clientId);
+        }
     }
 
     async handleP2PAnswer(client, sdp) {


### PR DESCRIPTION
## Summary
- TTS読み上げ時にマークダウンテーブルのパイプ文字 `|` や区切り線が発声される問題を修正
- ICE restart中にclosed PeerConnectionへoffer設定してクラッシュする問題を修正

Closes #17
Closes #19

## Test plan
- [x] npm test (60/60 passed)
- [x] Python構文チェック (両ファイルOK)

🤖 Generated with [Claude Code](https://claude.com/claude-code)