### PR TITLE
fix: cancel ICE restart timer when P2P recovers

### DIFF
--- a/ptt-box/stream_server/server.js
+++ b/ptt-box/stream_server/server.js
@@ -1503,6 +1503,16 @@ class StreamServer {
                         if (otherId !== client.clientId &&
                             otherClient.displayName === msg.displayName) {
                             log(`${msg.displayName}: Closing stale connection ${otherId} (replaced by ${client.clientId})`);
+                            // ws.close()は非同期のためhandleDisconnectの呼び出しが遅延する
+                            // タイマーは即座にキャンセルしないと旧接続のタイマーが発火してしまう
+                            if (otherClient.iceRestartTimer) {
+                                clearTimeout(otherClient.iceRestartTimer);
+                                otherClient.iceRestartTimer = null;
+                            }
+                            if (otherClient.offerTimeout) {
+                                clearTimeout(otherClient.offerTimeout);
+                                otherClient.offerTimeout = null;
+                            }
                             otherClient.ws.close(1000, 'Replaced by new connection');
                             break;
                         }

--- a/ptt-box/stream_server/server.js
+++ b/ptt-box/stream_server/server.js
@@ -2347,7 +2347,17 @@ class StreamServer {
                 if (connInfo.cleanupTimer) {
                     clearTimeout(connInfo.cleanupTimer);
                     connInfo.cleanupTimer = null;
-                    log(`P2P to ${client.displayName}: recovered, timer cancelled`);
+                    log(`P2P to ${client.displayName}: recovered, cleanup timer cancelled`);
+                }
+
+                // P2P回復 = ネットワーク復旧の兆候 → ICE restartタイマーをキャンセル
+                // メイン接続の回復にはもう少し時間がかかる場合がある
+                if (client.iceRestartTimer) {
+                    clearTimeout(client.iceRestartTimer);
+                    client.iceRestartTimer = null;
+                    client.iceRestartInProgress = false;
+                    client.iceRestartSuccessTime = Date.now();
+                    log(`${client.displayName}: ICE restart timer cancelled (P2P recovered)`);
                 }
 
             } else if (p2pPc.connectionState === 'failed' || p2pPc.connectionState === 'closed') {


### PR DESCRIPTION
## Summary

- P2P接続が`connected`に回復した際、ICE restartタイムアウトタイマーをキャンセルするように修正
- P2P回復はネットワーク復旧の兆候であり、メイン接続の回復にもう少し時間を与えるべきだが、タイマーが残存して10秒後にWebSocketを強制切断していた

## Root Cause

```
[05:13:25] ICE restart requested → timer set (10秒)
[05:13:26] P2P to Hiro: connected  ← P2P回復したがタイマーはキャンセルされず
[05:13:35] ICE restart timeout → WebSocket強制切断  ← ここが問題
```

## Changes

- P2P `connected` ハンドラで `client.iceRestartTimer` をクリア
- `iceRestartInProgress` を `false` にリセット（通常のdisconnectedハンドラが再動作可能に）
- `iceRestartSuccessTime` を設定（10秒クールダウンで即座の再トリガーを防止）
- `iceRestartAttempts` はリセットしない（メイン接続未回復のため安全カウンタは維持）
- ログメッセージを `"timer cancelled"` → `"cleanup timer cancelled"` に変更（タイマー種別の区別）

## Test plan

- [x] `npm test` — 既存60テスト全パス
- [ ] 実機テスト: モバイルでWiFi→4G切替後、P2P回復時にWebSocketが切断されないことを確認
- [ ] ログで `ICE restart timer cancelled (P2P recovered)` が出力されることを確認

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)