### PR TITLE
feat: ASSISTANT.local.md support & speaker device name resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ ptt-box/recordings/client_names.json
 .env
 .env.backup
 
+# Local prompt overrides
+ASSISTANT.local.md
+
 # Upload done markers
 *.updone
 

--- a/ptt-box/.env.example
+++ b/ptt-box/.env.example
@@ -56,7 +56,7 @@ ENABLE_AI_ASSISTANT=true
 # OpenAI API Key (必須)
 OPENAI_API_KEY=sk-...
 # 使用モデル
-AI_MODEL=gpt-4o-mini
+AI_MODEL=gpt-5.4-mini
 # 応答の最大トークン数 (ai_assistant.py のみ)
 AI_RESPONSE_MAX_TOKENS=500
 # ウェイクワード (カンマ区切り)

--- a/ptt-box/ai_assistant.py
+++ b/ptt-box/ai_assistant.py
@@ -65,7 +65,7 @@ if ENABLE_FILE_LOG:
 
 # ========== 設定 ==========
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-AI_MODEL = os.environ.get("AI_MODEL", "gpt-4o-mini")
+AI_MODEL = os.environ.get("AI_MODEL", "gpt-5.4-mini")
 AI_RESPONSE_MAX_TOKENS = int(os.environ.get("AI_RESPONSE_MAX_TOKENS", "500"))
 
 # 会話履歴設定
@@ -94,11 +94,22 @@ HEARTBEAT_INTERVAL = 30  # ハートビート送信間隔（秒）
 SYSTEM_PROMPT_PATH = Path(os.environ.get("SYSTEM_PROMPT_PATH", Path(__file__).parent / "ASSISTANT.md"))
 
 def load_system_prompt() -> str:
-    """システムプロンプトを外部ファイルから読み込む"""
+    """システムプロンプトを外部ファイルから読み込む
+    ASSISTANT.md（共通） + ASSISTANT.local.md（環境固有）をマージ
+    """
     if SYSTEM_PROMPT_PATH.exists():
-        return SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
+        prompt = SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
     else:
-        return "あなたはAIアシスタントです。簡潔に応答してください。"
+        prompt = "あなたはAIアシスタントです。簡潔に応答してください。"
+
+    # ローカル追加プロンプト（環境固有の設定）
+    local_path = SYSTEM_PROMPT_PATH.parent / "ASSISTANT.local.md"
+    if local_path.exists():
+        local_text = local_path.read_text(encoding="utf-8").strip()
+        if local_text:
+            prompt = prompt.rstrip() + "\n\n" + local_text
+
+    return prompt
 
 
 def log(msg: str, level: str = "info"):

--- a/ptt-box/ai_assistant_agent.py
+++ b/ptt-box/ai_assistant_agent.py
@@ -68,7 +68,7 @@ if ENABLE_FILE_LOG:
 
 # ========== 設定 ==========
 OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-AI_MODEL = os.environ.get("AI_MODEL", "gpt-4o-mini")
+AI_MODEL = os.environ.get("AI_MODEL", "gpt-5.4-mini")
 TTS_VOICE = os.environ.get("TTS_VOICE", "ja-JP-NanamiNeural")
 TTS_ENABLED = os.environ.get("TTS_ENABLED", "true").lower() == "true"
 TTS_VOLUME_GAIN = float(os.environ.get("TTS_VOLUME_GAIN", "1.5"))  # TTS音量ゲイン（1.0=等倍, 1.5=1.5倍）
@@ -131,11 +131,22 @@ def load_refine_prompt() -> str:
 
 
 def load_system_prompt(context=None, agent=None) -> str:
-    """システムプロンプトを外部ファイルから読み込む（毎回最新を読む）"""
+    """システムプロンプトを外部ファイルから読み込む（毎回最新を読む）
+    ASSISTANT.md（共通） + ASSISTANT.local.md（環境固有）をマージ
+    """
     if SYSTEM_PROMPT_PATH.exists():
-        return SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
+        prompt = SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
     else:
-        return "あなたはAIアシスタントです。簡潔に応答してください。"
+        prompt = "あなたはAIアシスタントです。簡潔に応答してください。"
+
+    # ローカル追加プロンプト（環境固有の設定）
+    local_path = SYSTEM_PROMPT_PATH.parent / "ASSISTANT.local.md"
+    if local_path.exists():
+        local_text = local_path.read_text(encoding="utf-8").strip()
+        if local_text:
+            prompt = prompt.rstrip() + "\n\n" + local_text
+
+    return prompt
 
 
 def log(msg: str, level: str = "info"):
@@ -315,6 +326,7 @@ def load_mcp_servers(config_path: Path) -> list:
             },
             cache_tools_list=True,
             tool_filter=tool_filter,
+            client_session_timeout_seconds=30,
         )
         servers.append(server)
         log(f"  MCP: {name} ({command})")
@@ -407,6 +419,7 @@ class AgentAssistant:
             self.manager = MCPServerManager(
                 servers,
                 drop_failed_servers=True,
+                connect_timeout_seconds=30,
             )
             await self.manager.__aenter__()
 

--- a/ptt-box/audio_output.py
+++ b/ptt-box/audio_output.py
@@ -7,10 +7,11 @@ stdin から連続OGG/Opusストリームを受け取り、指定デバイスに
   PTT間の無音時もプロセスは維持される
 
 Usage:
-  python audio_output.py [device_id]
+  python audio_output.py [device_id_or_name]
 
 Environment:
-  SPEAKER_DEVICE_ID - 出力デバイスID (コマンドライン引数が優先)
+  SPEAKER_DEVICE_NAME - 出力デバイス名（部分一致検索、優先）
+  SPEAKER_DEVICE_ID - 出力デバイスID (SPEAKER_DEVICE_NAMEが未設定時のフォールバック)
 """
 import sys
 import os
@@ -20,8 +21,6 @@ import queue
 import numpy as np
 import sounddevice as sd
 
-# 設定
-DEVICE_ID = int(sys.argv[1]) if len(sys.argv) > 1 else int(os.environ.get('SPEAKER_DEVICE_ID', 0))
 SAMPLE_RATE = 48000
 CHANNELS = 1
 BLOCKSIZE = 480  # 10ms @ 48kHz（低遅延）
@@ -29,7 +28,50 @@ BLOCKSIZE = 480  # 10ms @ 48kHz（低遅延）
 def log(msg):
     print(f"[audio_output] {msg}", file=sys.stderr, flush=True)
 
-log(f"Starting audio output to device {DEVICE_ID}")
+def find_device_by_name(name):
+    """デバイス名で出力デバイスを検索（部分一致）。見つからなければNone。"""
+    devices = sd.query_devices()
+    for i, dev in enumerate(devices):
+        if name in dev['name'] and dev['max_output_channels'] > 0:
+            return i, dev['name']
+    return None, None
+
+def resolve_device():
+    """コマンドライン引数 → SPEAKER_DEVICE_NAME → SPEAKER_DEVICE_ID の優先順でデバイスを決定"""
+    arg = sys.argv[1] if len(sys.argv) > 1 else None
+
+    # 引数が数値でない場合はデバイス名として扱う
+    if arg and not arg.isdigit():
+        device_id, device_name = find_device_by_name(arg)
+        if device_id is not None:
+            log(f"Device found by name '{arg}': id={device_id}, name={device_name}")
+            return device_id, device_name
+        log(f"WARNING: Device name '{arg}' not found, falling back to SPEAKER_DEVICE_ID")
+
+    # 引数が数値の場合はそのまま使う
+    if arg and arg.isdigit():
+        device_id = int(arg)
+        dev_info = sd.query_devices(device_id)
+        log(f"Device by ID: id={device_id}, name={dev_info['name']}")
+        return device_id, dev_info['name']
+
+    # 環境変数 SPEAKER_DEVICE_NAME で検索
+    env_name = os.environ.get('SPEAKER_DEVICE_NAME', '')
+    if env_name:
+        device_id, device_name = find_device_by_name(env_name)
+        if device_id is not None:
+            log(f"Device found by SPEAKER_DEVICE_NAME '{env_name}': id={device_id}, name={device_name}")
+            return device_id, device_name
+        log(f"WARNING: SPEAKER_DEVICE_NAME '{env_name}' not found, falling back to SPEAKER_DEVICE_ID")
+
+    # フォールバック: SPEAKER_DEVICE_ID
+    device_id = int(os.environ.get('SPEAKER_DEVICE_ID', 0))
+    dev_info = sd.query_devices(device_id)
+    log(f"Device by SPEAKER_DEVICE_ID: id={device_id}, name={dev_info['name']}")
+    return device_id, dev_info['name']
+
+DEVICE_ID, DEVICE_NAME = resolve_device()
+log(f"Starting audio output to device {DEVICE_ID} ({DEVICE_NAME})")
 
 # 音声データキュー（小さく = 低遅延）
 audio_queue = queue.Queue(maxsize=5)  # 5 * 10ms = 50ms max

--- a/ptt-box/stream_server/.env.example
+++ b/ptt-box/stream_server/.env.example
@@ -20,9 +20,12 @@ MIC_DEVICE=マイク (USB PnP Audio Device)
 MIC_SAMPLE_RATE=48000
 # マイク音量倍率 (1.0=等倍、2.0=2倍、3.0=3倍)
 MIC_VOLUME=1.0
-# スピーカーデバイス名 (空でシステムデフォルト)
+# スピーカーデバイス名 (空でシステムデフォルト、ffplay用)
 SPEAKER_DEVICE=
-# スピーカーデバイスID (audio_output.py用)
+# スピーカーデバイス名で自動検索 (audio_output.py用、部分一致)
+# Windows再起動でデバイスIDが変わっても安定して接続できる
+SPEAKER_DEVICE_NAME=USB PnP Audio Device
+# スピーカーデバイスID (SPEAKER_DEVICE_NAMEが未設定時のフォールバック)
 SPEAKER_DEVICE_ID=0
 # スピーカー出力ゲイン (dB、デフォルト6、audio_output.py経由のみ影響)
 OUTPUT_GAIN_DB=6

--- a/ptt-box/stream_server/server.js
+++ b/ptt-box/stream_server/server.js
@@ -37,7 +37,8 @@ const MIC_DEVICE = process.env.MIC_DEVICE || 'CABLE Output (VB-Audio Virtual Cab
 const MIC_VOLUME = parseFloat(process.env.MIC_VOLUME) || 1.0;  // マイク音量倍率（デフォルト1.0）
 const MIC_SAMPLE_RATE = parseInt(process.env.MIC_SAMPLE_RATE) || 48000;  // マイク入力サンプルレート
 const SPEAKER_DEVICE = process.env.SPEAKER_DEVICE || '';  // 空の場合はシステムデフォルト（ffplay用）
-const SPEAKER_DEVICE_ID = process.env.SPEAKER_DEVICE_ID || '0';  // デバイスID（Python用）
+const SPEAKER_DEVICE_NAME = process.env.SPEAKER_DEVICE_NAME || '';  // デバイス名検索（Python用、優先）
+const SPEAKER_DEVICE_ID = process.env.SPEAKER_DEVICE_ID || '0';  // デバイスID（Python用、フォールバック）
 const USE_PYTHON_AUDIO = process.env.USE_PYTHON_AUDIO === 'true';  // Python音声出力を使用
 const ENABLE_LOCAL_AUDIO = process.env.ENABLE_LOCAL_AUDIO !== 'false';  // デフォルト有効
 const ENABLE_SERVER_MIC = process.env.ENABLE_SERVER_MIC !== 'false';  // デフォルト有効
@@ -2906,7 +2907,9 @@ class StreamServer {
             // Python + sounddevice を使用（デバイス指定可能）
             const pythonScript = path.join(__dirname, '..', 'audio_output.py');
 
-            this.speakerProcess = spawn('uv', ['run', 'python', pythonScript, SPEAKER_DEVICE_ID], {
+            // デバイス名が指定されていればそれを優先、なければIDを渡す
+            const speakerArg = SPEAKER_DEVICE_NAME || SPEAKER_DEVICE_ID;
+            this.speakerProcess = spawn('uv', ['run', 'python', pythonScript, speakerArg], {
                 stdio: ['pipe', 'ignore', 'pipe'],
                 cwd: path.join(__dirname, '..')  // ptt-box ディレクトリで実行
             });
@@ -2928,7 +2931,7 @@ class StreamServer {
                 this.oggGranulePos = 0;
             });
 
-            log(`Speaker output started (Python, device=${SPEAKER_DEVICE_ID})`);
+            log(`Speaker output started (Python, device=${SPEAKER_DEVICE_NAME ? `name="${SPEAKER_DEVICE_NAME}"` : `id=${SPEAKER_DEVICE_ID}`})`);
         } else {
             // ffplay を使用（従来方式）
             const ffplayArgs = [


### PR DESCRIPTION
## Summary
- **ASSISTANT.local.md サポート**: 環境固有のプロンプトカスタマイズを共通の ASSISTANT.md を変更せずに追加可能に（ai_assistant.py / ai_assistant_agent.py）
- **スピーカーデバイス名解決**: Windows再起動でデバイスIDがずれる問題を修正。`SPEAKER_DEVICE_NAME` による名前ベースの自動検索を追加（#27）
- **その他**: AI_MODEL デフォルトを gpt-5.4-mini に更新、MCP接続タイムアウト設定追加

## Test plan
- [x] サーバーテスト全60件パス
- [x] デバイス名検索の動作確認済み
- [ ] サーバー再起動後にスピーカー出力が正しいデバイスに接続されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)