### PR TITLE
feat: カラーテーマ着せ替え機能（5テーマ対応）

### DIFF
--- a/ptt-box/stream_client/dash/dash.css
+++ b/ptt-box/stream_client/dash/dash.css
@@ -6,8 +6,8 @@
 
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    background: #1a1a2e;
-    color: #eee;
+    background: var(--bg-page);
+    color: var(--text-primary);
     min-height: 100vh;
 }
 
@@ -27,7 +27,7 @@ body {
 }
 
 .login-box {
-    background: #16213e;
+    background: var(--bg-card);
     padding: 2rem;
     border-radius: 8px;
     text-align: center;
@@ -36,25 +36,25 @@ body {
 
 .login-box h1 {
     margin-bottom: 1.5rem;
-    color: #60efff;
+    color: var(--accent);
 }
 
 .login-box input {
     width: 100%;
     padding: 0.75rem;
     margin-bottom: 1rem;
-    border: 1px solid #333;
+    border: 1px solid var(--border-main);
     border-radius: 4px;
-    background: #0f0f23;
-    color: #eee;
+    background: var(--bg-chat);
+    color: var(--text-primary);
     font-size: 1rem;
 }
 
 .login-box button {
     width: 100%;
     padding: 0.75rem;
-    background: #60efff;
-    color: #000;
+    background: var(--accent);
+    color: var(--text-dark);
     border: none;
     border-radius: 4px;
     font-size: 1rem;
@@ -62,11 +62,11 @@ body {
 }
 
 .login-box button:hover {
-    background: #4dd9e6;
+    background: var(--accent-hover);
 }
 
 .error {
-    color: #e94560;
+    color: var(--status-error);
     margin-top: 1rem;
 }
 
@@ -81,13 +81,13 @@ header {
     justify-content: space-between;
     align-items: center;
     padding: 1rem 2rem;
-    background: #16213e;
-    border-bottom: 1px solid #333;
+    background: var(--bg-card);
+    border-bottom: 1px solid var(--border-main);
 }
 
 header h1 {
     font-size: 1.25rem;
-    color: #60efff;
+    color: var(--accent);
 }
 
 main {
@@ -102,14 +102,14 @@ main {
 }
 
 .card {
-    background: #16213e;
+    background: var(--bg-card);
     border-radius: 8px;
     padding: 1.5rem;
 }
 
 .card h2 {
     font-size: 1rem;
-    color: #888;
+    color: var(--text-secondary);
     margin-bottom: 1rem;
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -133,7 +133,7 @@ main {
 
 .status-item .label {
     font-size: 0.75rem;
-    color: #888;
+    color: var(--text-secondary);
     margin-bottom: 0.25rem;
 }
 
@@ -180,17 +180,17 @@ main {
 }
 
 .status-inline .label {
-    color: #888;
+    color: var(--text-secondary);
     font-size: 0.75rem;
 }
 
 .status-inline .value {
     font-weight: 600;
-    color: #eee;
+    color: var(--text-primary);
 }
 
 .status-inline .value-sub {
-    color: #888;
+    color: var(--text-secondary);
     font-size: 0.8rem;
 }
 
@@ -228,18 +228,18 @@ button:disabled {
 }
 
 .btn-secondary {
-    background: #333;
-    color: #eee;
+    background: var(--border-main);
+    color: var(--text-primary);
 }
 
 .btn-danger {
-    background: #e94560;
-    color: #fff;
+    background: var(--status-error);
+    color: var(--text-primary);
 }
 
 .btn-warning {
-    background: #f5a623;
-    color: #000;
+    background: var(--status-warning);
+    color: var(--text-dark);
 }
 
 .btn-small {
@@ -256,17 +256,17 @@ table {
 th, td {
     padding: 0.75rem;
     text-align: left;
-    border-bottom: 1px solid #333;
+    border-bottom: 1px solid var(--border-main);
 }
 
 th {
-    color: #888;
+    color: var(--text-secondary);
     font-size: 0.75rem;
     text-transform: uppercase;
 }
 
 tbody tr:hover {
-    background: rgba(255, 255, 255, 0.05);
+    background: var(--table-hover);
 }
 
 /* フッター */
@@ -274,35 +274,35 @@ footer {
     display: flex;
     justify-content: space-between;
     padding: 0.75rem 2rem;
-    background: #16213e;
-    border-top: 1px solid #333;
+    background: var(--bg-card);
+    border-top: 1px solid var(--border-main);
     font-size: 0.75rem;
-    color: #888;
+    color: var(--text-secondary);
 }
 
 /* 状態インジケーター */
 .state-idle {
-    color: #888;
+    color: var(--text-secondary);
 }
 
 .state-transmitting {
-    color: #e94560;
+    color: var(--status-error);
 }
 
 .state-running {
-    color: #4ade80;
+    color: var(--status-success);
 }
 
 .state-stopped {
-    color: #888;
+    color: var(--text-secondary);
 }
 
 .state-connected {
-    color: #4ade80;
+    color: var(--status-success);
 }
 
 .state-disconnected {
-    color: #e94560;
+    color: var(--status-error);
 }
 
 /* モバイル対応 */

--- a/ptt-box/stream_client/dash/dash.css
+++ b/ptt-box/stream_client/dash/dash.css
@@ -233,13 +233,15 @@ button:disabled {
 }
 
 .btn-danger {
-    background: var(--status-error);
-    color: var(--text-primary);
+    background: var(--btn-danger-bg);
+    border: 1px solid var(--btn-danger-border);
+    color: var(--btn-danger-text);
 }
 
 .btn-warning {
-    background: var(--status-warning);
-    color: var(--text-dark);
+    background: var(--btn-warning-bg);
+    border: 1px solid var(--btn-warning-border);
+    color: var(--btn-warning-text);
 }
 
 .btn-small {

--- a/ptt-box/stream_client/dash/index.html
+++ b/ptt-box/stream_client/dash/index.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <script>document.documentElement.dataset.theme = localStorage.getItem('ptt-theme') || 'midnight';</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ダッシュボード</title>
+    <link rel="stylesheet" href="../themes.css">
     <link rel="stylesheet" href="dash.css">
 </head>
 <body>

--- a/ptt-box/stream_client/index.html
+++ b/ptt-box/stream_client/index.html
@@ -99,6 +99,8 @@
         }
         button:not(.ptt-button).secondary {
             background: var(--btn-secondary);
+            border: 1px solid var(--btn-secondary-border);
+            color: var(--btn-secondary-text);
         }
         button:not(.ptt-button).secondary:hover:not(:disabled) {
             background: var(--btn-secondary-hover);
@@ -396,8 +398,8 @@
         .history-edit-btn {
             padding: 6px 12px;
             background: var(--btn-secondary);
-            border: none;
-            color: var(--text-tertiary);
+            border: 1px solid var(--btn-secondary-border);
+            color: var(--btn-secondary-text);
             font-size: 12px;
             border-radius: 4px;
             cursor: pointer;
@@ -502,8 +504,8 @@
         }
         .modal-btn-secondary {
             background: var(--btn-secondary);
-            color: var(--text-primary);
-            border: none;
+            color: var(--btn-secondary-text);
+            border: 1px solid var(--btn-secondary-border);
         }
 
         /* Clients Count */
@@ -614,7 +616,7 @@
             border: 1px solid var(--border-main);
             border-radius: 6px;
             background: var(--bg-input);
-            color: var(--text-white);
+            color: var(--text-primary);
             font-size: 16px;
             font-family: inherit;
             resize: vertical;
@@ -642,9 +644,9 @@
             flex: 1;
             padding: 12px 16px;
             background: var(--btn-voice);
-            border: none;
+            border: 1px solid var(--btn-secondary-border);
             border-radius: 6px;
-            color: var(--text-white);
+            color: var(--btn-secondary-text);
             font-size: 14px;
             cursor: pointer;
             transition: background 0.2s;
@@ -798,9 +800,9 @@
             width: 100%;
             padding: 10px;
             background: var(--btn-secondary);
-            border: none;
+            border: 1px solid var(--btn-secondary-border);
             border-radius: 6px;
-            color: var(--text-tertiary);
+            color: var(--btn-secondary-text);
             font-size: 13px;
             cursor: pointer;
             transition: background 0.2s;
@@ -939,7 +941,7 @@
             </div>
 
             <div style="margin-top: 10px;">
-                <button onclick="openSettings()" style="background: var(--btn-secondary); padding: 8px 16px; font-size: 14px; width: 100%;">⚙️ 設定</button>
+                <button onclick="openSettings()" style="background: var(--btn-secondary); border: 1px solid var(--btn-secondary-border); color: var(--btn-secondary-text); padding: 8px 16px; font-size: 14px; width: 100%;">⚙️ 設定</button>
             </div>
 
             <div id="debugButtonContainer" style="margin-top: 10px; display: none;">
@@ -981,7 +983,7 @@
         <!-- History Tab -->
         <div id="tab-history" class="tab-content">
             <div style="display: flex; align-items: center; gap: 15px; margin-bottom: 10px;">
-                <button onclick="loadHistory()" style="background: var(--btn-secondary); padding: 10px 20px; font-size: 14px;">更新</button>
+                <button onclick="loadHistory()" style="background: var(--btn-secondary); border: 1px solid var(--btn-secondary-border); color: var(--btn-secondary-text); padding: 10px 20px; font-size: 14px;">更新</button>
                 <div style="flex: 1; display: flex; align-items: center; gap: 8px;">
                     <span style="font-size: 16px;">🔊</span>
                     <input type="range" id="historyVolumeSlider" min="0" max="100" value="40"
@@ -1038,7 +1040,7 @@
                     <div style="margin-bottom: 10px; font-weight: 500;">表示名</div>
                     <div style="display: flex; gap: 10px; align-items: center;">
                         <input type="text" id="displayNameInput" placeholder="名前を入力" maxlength="20" style="flex: 1; padding: 12px; background: var(--bg-input); border: 1px solid var(--border-main); border-radius: 6px; color: var(--text-primary); font-size: 14px;">
-                        <button onclick="saveDisplayName()" style="padding: 12px 20px; background: var(--btn-secondary); border: none; color: var(--text-primary); border-radius: 6px; cursor: pointer;">保存</button>
+                        <button onclick="saveDisplayName()" style="padding: 12px 20px; background: var(--btn-secondary); border: 1px solid var(--btn-secondary-border); color: var(--btn-secondary-text); border-radius: 6px; cursor: pointer;">保存</button>
                     </div>
                     <div id="displayNameHint" style="margin-top: 10px; font-size: 12px; color: var(--text-secondary);">他のユーザーに表示される名前です</div>
                 </div>
@@ -1046,7 +1048,7 @@
                     <div style="margin-bottom: 10px; font-weight: 500;">PTTショートカットキー</div>
                     <div style="display: flex; gap: 10px; align-items: center;">
                         <div id="pttKeyDisplay" style="flex: 1; padding: 12px; background: var(--bg-input); border-radius: 6px; text-align: center; font-family: monospace;">Ctrl+Space</div>
-                        <button onclick="startKeyRegistration()" id="registerKeyBtn" style="padding: 12px 20px; background: var(--btn-secondary); border: none; color: var(--text-primary); border-radius: 6px; cursor: pointer;">登録</button>
+                        <button onclick="startKeyRegistration()" id="registerKeyBtn" style="padding: 12px 20px; background: var(--btn-secondary); border: 1px solid var(--btn-secondary-border); color: var(--btn-secondary-text); border-radius: 6px; cursor: pointer;">登録</button>
                     </div>
                     <div id="keyRegistrationHint" style="margin-top: 10px; font-size: 12px; color: var(--text-secondary); display: none;">キーを押してください...</div>
                 </div>

--- a/ptt-box/stream_client/index.html
+++ b/ptt-box/stream_client/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <script>document.documentElement.dataset.theme = localStorage.getItem('ptt-theme') || 'midnight';</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#16213e">
@@ -9,6 +10,7 @@
     <link rel="manifest" href="manifest.json">
     <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192.png">
     <link rel="apple-touch-icon" href="icons/icon-192.png">
+    <link rel="stylesheet" href="themes.css">
     <title>Webトランシーバー</title>
     <style>
         * {
@@ -22,12 +24,12 @@
             max-width: 600px;
             margin: 5px auto;
             padding: 5px;
-            background: #1a1a2e;
-            color: #eee;
+            background: var(--bg-page);
+            color: var(--text-primary);
             overscroll-behavior: none;  /* プルダウンリロード抑制 */
         }
         .container {
-            background: #16213e;
+            background: var(--bg-card);
             border-radius: 12px;
             padding: 10px 15px;
             text-align: center;
@@ -48,38 +50,38 @@
             transition: all 0.2s;
         }
         .connection-toggle.disconnected {
-            background: #641220 !important;
-            color: #f8d7da;
+            background: var(--status-error-bg) !important;
+            color: var(--status-error-text);
         }
         .connection-toggle.connecting {
-            background: #3d405b !important;
-            color: #f4f1de;
+            background: var(--btn-secondary) !important;
+            color: var(--status-neutral);
         }
         .connection-toggle.connected {
-            background: #1b4332 !important;
-            color: #95d5b2;
+            background: var(--status-success-bg) !important;
+            color: var(--status-success-soft);
         }
         .connection-toggle.preparing {
-            background: #5c4d1a !important;
-            color: #f4f1de;
+            background: var(--status-warning-bg) !important;
+            color: var(--status-neutral);
         }
         .connection-toggle.blocked {
-            background: #4a1942 !important;
-            color: #e8b4d8;
+            background: var(--status-blocked-bg) !important;
+            color: var(--status-blocked-text);
         }
         .connection-indicator {
             width: 10px;
             height: 10px;
             border-radius: 50%;
         }
-        .disconnected .connection-indicator { background: #e94560; }
-        .connecting .connection-indicator { background: #f4f1de; animation: pulse 1s infinite; }
-        .connected .connection-indicator { background: #95d5b2; }
-        .preparing .connection-indicator { background: #f4f1de; animation: pulse 1s infinite; }
-        .blocked .connection-indicator { background: #e8b4d8; }
-        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]) {
-            background: #e94560;
-            color: white;
+        .disconnected .connection-indicator { background: var(--status-error); }
+        .connecting .connection-indicator { background: var(--status-neutral); animation: pulse 1s infinite; }
+        .connected .connection-indicator { background: var(--status-success-soft); }
+        .preparing .connection-indicator { background: var(--status-neutral); animation: pulse 1s infinite; }
+        .blocked .connection-indicator { background: var(--status-blocked-text); }
+        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]):not(.theme-swatch) {
+            background: var(--status-error);
+            color: var(--text-white);
             border: none;
             padding: 12px 30px;
             font-size: 16px;
@@ -88,28 +90,28 @@
             margin: 5px;
             transition: background 0.2s;
         }
-        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]):hover:not(:disabled) {
-            background: #ff6b6b;
+        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]):not(.theme-swatch):hover:not(:disabled) {
+            background: var(--status-error-hover);
         }
-        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]):disabled {
-            background: #555;
+        button:not(.ptt-button):not(.clients-badge):not(.history-edit-btn):not(.connection-toggle):not(.tab-btn):not(.modal-close):not(.clients-popup-close):not([class^="ai-btn"]):not(.theme-swatch):disabled {
+            background: var(--btn-disabled);
             cursor: not-allowed;
         }
         button:not(.ptt-button).secondary {
-            background: #3d405b;
+            background: var(--btn-secondary);
         }
         button:not(.ptt-button).secondary:hover:not(:disabled) {
-            background: #5c5f7e;
+            background: var(--btn-secondary-hover);
         }
         .volume-meter {
             height: 4px;
-            background: #0a1628;
+            background: var(--bg-meter);
             border-radius: 2px;
             overflow: hidden;
         }
         .volume-bar {
             height: 100%;
-            background: linear-gradient(90deg, #00ff87, #60efff);
+            background: linear-gradient(90deg, var(--gradient-volume-start), var(--gradient-volume-end));
             width: 0%;
             transition: width 0.05s;
             border-radius: 2px;
@@ -117,7 +119,7 @@
         .info {
             margin-top: 20px;
             font-size: 12px;
-            color: #888;
+            color: var(--text-secondary);
         }
         /* PTT Button */
         .ptt-container {
@@ -135,24 +137,24 @@
             transition: border-color 0.15s, box-shadow 0.15s;
         }
         .ptt-ring.active {
-            border-color: #e94560;
-            box-shadow: 0 0 30px rgba(233, 69, 96, 0.5);
+            border-color: var(--status-error);
+            box-shadow: 0 0 30px var(--status-error-alpha-50);
         }
         .ptt-ring.transmitting {
-            border-color: #e94560;
-            box-shadow: 0 0 30px rgba(233, 69, 96, 0.5);
+            border-color: var(--status-error);
+            box-shadow: 0 0 30px var(--status-error-alpha-50);
         }
         .ptt-ring.receiving {
-            border-color: #95d5b2;
-            box-shadow: 0 0 30px rgba(149, 213, 178, 0.5);
+            border-color: var(--status-success-soft);
+            box-shadow: 0 0 30px var(--status-success-alpha-50);
         }
         .ptt-button {
             width: 140px;
             height: 140px;
             border-radius: 50%;
-            background: #3d405b;
-            border: 5px solid #555;
-            color: #eee;
+            background: var(--btn-secondary);
+            border: 5px solid var(--border-light);
+            color: var(--text-primary);
             cursor: pointer;
             display: flex;
             flex-direction: column;
@@ -170,8 +172,8 @@
         .ptt-button.transmitting,
         .ptt-button.receiving {
             /* 内側ボタンは色を変えない（外側リングが変わる） */
-            background: #3d405b !important;
-            border-color: #555 !important;
+            background: var(--btn-secondary) !important;
+            border-color: var(--border-light) !important;
             box-shadow: none !important;
         }
         .ptt-button.pressing,
@@ -179,8 +181,8 @@
             transform: scale(0.95);
         }
         .ptt-button:disabled {
-            background: #333;
-            border-color: #444;
+            background: var(--border-main);
+            border-color: var(--border-medium);
             cursor: not-allowed;
             opacity: 0.5;
         }
@@ -191,8 +193,8 @@
         @media (hover: none) {
             .ptt-button:hover,
             .ptt-button:focus {
-                background: #3d405b;
-                border-color: #555;
+                background: var(--btn-secondary);
+                border-color: var(--border-light);
                 transform: none;
                 box-shadow: none;
             }
@@ -212,7 +214,7 @@
             gap: 8px;
             width: 100%;
             padding: 6px 15px;
-            background: #0f3460;
+            background: var(--bg-section);
             border-radius: 8px;
             margin: 0 0 8px 0;
             font-size: 13px;
@@ -221,14 +223,14 @@
             width: 10px;
             height: 10px;
             border-radius: 50%;
-            background: #666;
+            background: var(--text-muted);
         }
         .speaker-indicator.transmitting {
-            background: #e94560;
+            background: var(--status-error);
             animation: pulse 1s infinite;
         }
         .speaker-indicator.receiving {
-            background: #95d5b2;
+            background: var(--status-success-soft);
             animation: pulse 1s infinite;
         }
         @keyframes pulse {
@@ -243,12 +245,12 @@
             gap: 8px;
             font-size: 11px;
             padding: 4px 8px;
-            background: rgba(244, 67, 54, 0.2);
+            background: var(--service-error-alpha-20);
             border-radius: 4px;
             margin-bottom: 8px;
         }
         .service-status.hidden { display: none; }
-        .service-status-label { color: #f44336; }
+        .service-status-label { color: var(--status-service-down); }
         .service-item {
             display: flex;
             align-items: center;
@@ -259,10 +261,10 @@
             height: 8px;
             border-radius: 50%;
         }
-        .service-dot.up { background: #4caf50; }
-        .service-dot.down { background: #f44336; }
-        .service-dot.unknown { background: #9e9e9e; }
-        .service-name { color: #ccc; }
+        .service-dot.up { background: var(--status-service-up); }
+        .service-dot.down { background: var(--status-service-down); }
+        .service-dot.unknown { background: var(--status-service-unknown); }
+        .service-name { color: var(--text-light); }
 
         /* Tab Navigation */
         .tab-nav {
@@ -274,19 +276,19 @@
             padding: 8px;
             background: transparent !important;
             border: none;
-            color: #666;
+            color: var(--text-muted);
             cursor: pointer;
             font-size: 14px;
             margin: 0;
-            border-bottom: 2px solid #0f3460;
+            border-bottom: 2px solid var(--bg-section);
             transition: color 0.2s, border-color 0.2s;
         }
         .tab-btn:hover {
-            color: #aaa;
+            color: var(--text-tertiary);
         }
         .tab-btn.active {
-            color: #60efff;
-            border-bottom-color: #60efff;
+            color: var(--accent);
+            border-bottom-color: var(--accent);
         }
         .tab-content {
             display: none;
@@ -308,7 +310,7 @@
             justify-content: center;
             align-items: center;
             padding: 15px;
-            color: #60efff;
+            color: var(--accent);
             font-size: 14px;
         }
         .pull-indicator.visible {
@@ -320,7 +322,7 @@
         .pull-indicator .spinner {
             width: 20px;
             height: 20px;
-            border: 2px solid #60efff;
+            border: 2px solid var(--accent);
             border-top-color: transparent;
             border-radius: 50%;
             animation: spin 0.8s linear infinite;
@@ -336,7 +338,7 @@
             display: flex;
             flex-direction: column;
             padding: 12px;
-            background: #0f3460;
+            background: var(--bg-section);
             border-radius: 8px;
             margin-bottom: 8px;
             cursor: pointer;
@@ -344,10 +346,10 @@
             gap: 6px;
         }
         .history-item:hover {
-            background: #1a4a7a;
+            background: var(--bg-hover);
         }
         .history-item.playing {
-            background: #1b4332;
+            background: var(--status-success-bg);
         }
         .history-row1 {
             display: flex;
@@ -359,13 +361,13 @@
         }
         .history-play-icon {
             font-size: 16px;
-            color: #888;
+            color: var(--text-secondary);
             flex-shrink: 0;
             width: 20px;
             text-align: center;
         }
         .history-item.playing .history-play-icon {
-            color: #e94560;
+            color: var(--status-error);
         }
         .source-badge {
             font-size: 16px;
@@ -373,8 +375,8 @@
         }
         .client-id {
             font-size: 0.75em;
-            color: #60efff;
-            background: rgba(96, 239, 255, 0.1);
+            color: var(--accent);
+            background: var(--accent-alpha-10);
             padding: 2px 6px;
             border-radius: 3px;
             font-family: monospace;
@@ -382,20 +384,20 @@
         }
         .history-datetime {
             font-size: 12px;
-            color: #60efff;
+            color: var(--accent);
         }
         .history-preview {
             font-size: 13px;
-            color: #aaa;
+            color: var(--text-tertiary);
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
         .history-edit-btn {
             padding: 6px 12px;
-            background: #3d405b;
+            background: var(--btn-secondary);
             border: none;
-            color: #aaa;
+            color: var(--text-tertiary);
             font-size: 12px;
             border-radius: 4px;
             cursor: pointer;
@@ -403,17 +405,17 @@
             margin-left: auto;
         }
         .history-edit-btn:hover {
-            background: #5c5f7e;
-            color: #fff;
+            background: var(--btn-secondary-hover);
+            color: var(--text-white);
         }
         .history-empty {
             text-align: center;
-            color: #666;
+            color: var(--text-muted);
             padding: 40px 20px;
         }
         .history-loading {
             text-align: center;
-            color: #888;
+            color: var(--text-secondary);
             padding: 40px 20px;
         }
 
@@ -425,7 +427,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.8);
+            background: var(--overlay-dark);
             z-index: 1000;
             align-items: center;
             justify-content: center;
@@ -435,7 +437,7 @@
             display: flex;
         }
         .modal-content {
-            background: #16213e;
+            background: var(--bg-card);
             border-radius: 12px;
             width: 100%;
             max-width: 600px;
@@ -448,7 +450,7 @@
             justify-content: space-between;
             align-items: center;
             padding: 15px 20px;
-            border-bottom: 1px solid #0f3460;
+            border-bottom: 1px solid var(--bg-section);
         }
         .modal-title {
             font-size: 16px;
@@ -457,7 +459,7 @@
         .modal-close {
             background: none;
             border: none;
-            color: #888;
+            color: var(--text-secondary);
             font-size: 24px;
             cursor: pointer;
             padding: 0;
@@ -471,10 +473,10 @@
         .modal-textarea {
             width: 100%;
             height: 300px;
-            background: #0a0a15;
-            border: 1px solid #0f3460;
+            background: var(--bg-input);
+            border: 1px solid var(--bg-section);
             border-radius: 6px;
-            color: #eee;
+            color: var(--text-primary);
             font-family: monospace;
             font-size: 13px;
             padding: 12px;
@@ -484,7 +486,7 @@
             display: flex;
             gap: 10px;
             padding: 15px 20px;
-            border-top: 1px solid #0f3460;
+            border-top: 1px solid var(--bg-section);
             justify-content: flex-end;
         }
         .modal-btn {
@@ -494,13 +496,13 @@
             cursor: pointer;
         }
         .modal-btn-primary {
-            background: #60efff;
-            color: #1a1a2e;
+            background: var(--accent);
+            color: var(--accent-on-accent-dark);
             border: none;
         }
         .modal-btn-secondary {
-            background: #3d405b;
-            color: #eee;
+            background: var(--btn-secondary);
+            color: var(--text-primary);
             border: none;
         }
 
@@ -508,7 +510,7 @@
         .clients-badge {
             background: none;
             border: none;
-            color: #888;
+            color: var(--text-secondary);
             font-size: 12px;
             cursor: pointer;
             display: none;
@@ -516,7 +518,7 @@
             margin: 0;
         }
         .clients-badge:hover {
-            color: #60efff;
+            color: var(--accent);
         }
         .clients-badge.visible {
             display: inline;
@@ -528,14 +530,14 @@
             top: 50%;
             left: 50%;
             transform: translate(-50%, -50%);
-            background: #16213e;
+            background: var(--bg-card);
             border-radius: 12px;
             min-width: 250px;
             max-width: 90%;
             max-height: 60vh;
             z-index: 1001;
             display: none;
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+            box-shadow: 0 4px 20px var(--shadow-popup);
         }
         .clients-popup.active {
             display: block;
@@ -545,7 +547,7 @@
             justify-content: space-between;
             align-items: center;
             padding: 12px 16px;
-            border-bottom: 1px solid #0f3460;
+            border-bottom: 1px solid var(--bg-section);
         }
         .clients-popup-title {
             font-size: 14px;
@@ -554,7 +556,7 @@
         .clients-popup-close {
             background: none;
             border: none;
-            color: #888;
+            color: var(--text-secondary);
             font-size: 20px;
             cursor: pointer;
             padding: 0;
@@ -572,19 +574,19 @@
             padding: 10px 16px;
         }
         .client-item-popup:hover {
-            background: #0f3460;
+            background: var(--bg-section);
         }
         .client-icon {
             font-size: 16px;
         }
         .client-name-popup {
             font-size: 14px;
-            color: #eee;
+            color: var(--text-primary);
         }
         .no-clients-popup {
             padding: 20px;
             text-align: center;
-            color: #888;
+            color: var(--text-secondary);
             font-size: 14px;
         }
         .clients-overlay {
@@ -593,7 +595,7 @@
             left: 0;
             right: 0;
             bottom: 0;
-            background: rgba(0, 0, 0, 0.5);
+            background: var(--overlay-medium);
             z-index: 1000;
             display: none;
         }
@@ -609,10 +611,10 @@
         #aiQueryInput {
             width: 100%;
             padding: 12px;
-            border: 1px solid #333;
+            border: 1px solid var(--border-main);
             border-radius: 6px;
-            background: #0a0a15;
-            color: #fff;
+            background: var(--bg-input);
+            color: var(--text-white);
             font-size: 16px;
             font-family: inherit;
             resize: vertical;
@@ -621,14 +623,14 @@
             overflow-y: auto;
         }
         #aiQueryInput::placeholder {
-            color: #666;
+            color: var(--text-muted);
         }
         @keyframes ai-pulse-border {
-            0%, 100% { border-color: #2ed573; }
-            50% { border-color: #1a8a4e; }
+            0%, 100% { border-color: var(--status-success-bright); }
+            50% { border-color: var(--status-success-border-dim); }
         }
         #aiQueryInput.voice-active {
-            border: 2px solid #2ed573;
+            border: 2px solid var(--status-success-bright);
             animation: ai-pulse-border 1.5s infinite;
         }
         .ai-button-row {
@@ -639,10 +641,10 @@
         .ai-btn-voice {
             flex: 1;
             padding: 12px 16px;
-            background: #4a4a6a;
+            background: var(--btn-voice);
             border: none;
             border-radius: 6px;
-            color: #fff;
+            color: var(--text-white);
             font-size: 14px;
             cursor: pointer;
             transition: background 0.2s;
@@ -652,29 +654,29 @@
             user-select: none;
         }
         .ai-btn-voice:hover:not(:disabled) {
-            background: #5a5a7a;
+            background: var(--btn-voice-hover);
         }
         .ai-btn-voice:disabled {
             opacity: 0.5;
             cursor: not-allowed;
         }
         .ai-btn-voice.listening {
-            background: #2ed573;
+            background: var(--status-success-bright);
             animation: pulse 1.5s infinite;
         }
         .ai-btn-send {
             flex: 1;
             padding: 12px 16px;
-            background: #00d9ff;
+            background: var(--accent-ai);
             border: none;
             border-radius: 6px;
-            color: #000;
+            color: var(--accent-on-accent);
             font-size: 14px;
             cursor: pointer;
             transition: background 0.2s;
         }
         .ai-btn-send:hover:not(:disabled) {
-            background: #00b8d9;
+            background: var(--accent-ai-hover);
         }
         .ai-btn-send:disabled {
             opacity: 0.5;
@@ -688,23 +690,23 @@
         }
         .ai-mic-status {
             font-size: 12px;
-            color: #888;
+            color: var(--text-secondary);
         }
         .ai-btn-stop {
             padding: 8px 16px;
-            background: #ff6b6b;
+            background: var(--status-error-hover);
             border: none;
             border-radius: 6px;
-            color: #fff;
+            color: var(--text-white);
             font-size: 13px;
             cursor: pointer;
             transition: background 0.2s;
         }
         .ai-btn-stop:hover {
-            background: #ee5a5a;
+            background: var(--btn-stop-hover);
         }
         .ai-chat-container {
-            background: #0f0f23;
+            background: var(--bg-chat);
             border-radius: 6px;
             min-height: 200px;
             max-height: calc(100vh - 380px);
@@ -713,37 +715,37 @@
         }
         .ai-chat-message {
             padding: 12px 16px;
-            border-bottom: 1px solid #2a2a3a;
+            border-bottom: 1px solid var(--chat-divider);
         }
         .ai-chat-message:last-child {
             border-bottom: none;
         }
         .ai-chat-message.user {
-            background: #1e3a5f;
+            background: var(--chat-user-bg);
         }
         .ai-chat-message.ai {
-            background: #16213e;
+            background: var(--bg-card);
         }
         .ai-chat-message .role {
             font-size: 12px;
             font-weight: bold;
-            color: #00d9ff;
+            color: var(--accent-ai);
             margin-bottom: 6px;
         }
         .ai-chat-message .content {
-            color: #eee;
+            color: var(--text-primary);
             line-height: 1.5;
             font-size: 14px;
         }
         .ai-chat-message .content code {
-            background: #0f0f23;
+            background: var(--bg-chat);
             padding: 2px 6px;
             border-radius: 3px;
             font-family: 'Monaco', 'Menlo', monospace;
             font-size: 0.9em;
         }
         .ai-chat-message .content pre {
-            background: #0f0f23;
+            background: var(--bg-chat);
             padding: 10px;
             border-radius: 4px;
             overflow-x: auto;
@@ -764,21 +766,21 @@
             margin-bottom: 0;
         }
         .ai-chat-message.loading .content {
-            color: #888;
+            color: var(--text-secondary);
             font-style: italic;
         }
         .ai-chat-message.error .content {
-            color: #ff6b6b;
+            color: var(--status-error-hover);
         }
         .ai-chat-message.streaming .content {
-            color: #ddd;
+            color: var(--text-streaming);
         }
         .ai-chat-message.streaming .ai-status {
-            color: #888;
+            color: var(--text-secondary);
             font-style: italic;
         }
         .ai-chat-empty {
-            color: #666;
+            color: var(--text-muted);
             text-align: center;
             padding: 40px 20px;
             font-style: italic;
@@ -795,17 +797,17 @@
         .ai-btn-clear {
             width: 100%;
             padding: 10px;
-            background: #3d405b;
+            background: var(--btn-secondary);
             border: none;
             border-radius: 6px;
-            color: #aaa;
+            color: var(--text-tertiary);
             font-size: 13px;
             cursor: pointer;
             transition: background 0.2s;
         }
         .ai-btn-clear:hover {
-            background: #5c5f7e;
-            color: #fff;
+            background: var(--btn-secondary-hover);
+            color: var(--text-white);
         }
         /* Information Toast */
         .info-toast-container {
@@ -824,13 +826,13 @@
             align-items: flex-start;
             gap: 10px;
             padding: 12px 14px;
-            background: rgba(22, 33, 62, 0.92);
+            background: var(--toast-bg);
             backdrop-filter: blur(8px);
-            border: 1px solid rgba(255, 255, 255, 0.1);
+            border: 1px solid var(--toast-border);
             border-radius: 10px;
-            color: #eee;
+            color: var(--text-primary);
             font-size: 13px;
-            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+            box-shadow: 0 4px 16px var(--shadow-toast);
             opacity: 0;
             transform: translateX(40px);
             transition: opacity 0.3s, transform 0.3s;
@@ -858,7 +860,7 @@
             margin-bottom: 2px;
         }
         .info-toast-text {
-            color: #bbb;
+            color: var(--text-dim);
             word-break: break-word;
         }
     </style>
@@ -923,7 +925,7 @@
             <div style="margin-top: 12px; display: flex; align-items: center; gap: 10px;">
                 <span style="font-size: 20px;" title="PCストリーム">🔈</span>
                 <input type="range" id="volumeSlider" min="0" max="100" value="40"
-                       style="flex: 1; height: 8px; cursor: pointer; accent-color: #60efff;"
+                       style="flex: 1; height: 8px; cursor: pointer; accent-color: var(--accent);"
                        oninput="setVolume(this.value)">
                 <span id="volumeValue" style="min-width: 40px; text-align: right;">40%</span>
             </div>
@@ -931,22 +933,22 @@
             <div style="margin-top: 8px; display: flex; align-items: center; gap: 10px;">
                 <span style="font-size: 20px;" title="P2P音声">👥</span>
                 <input type="range" id="p2pVolumeSlider" min="0" max="100" value="40"
-                       style="flex: 1; height: 8px; cursor: pointer; accent-color: #f39c12;"
+                       style="flex: 1; height: 8px; cursor: pointer; accent-color: var(--slider-p2p);"
                        oninput="setP2PVolume(this.value)">
                 <span id="p2pVolumeValue" style="min-width: 40px; text-align: right;">40%</span>
             </div>
 
             <div style="margin-top: 10px;">
-                <button onclick="openSettings()" style="background: #3d405b; padding: 8px 16px; font-size: 14px; width: 100%;">⚙️ 設定</button>
+                <button onclick="openSettings()" style="background: var(--btn-secondary); padding: 8px 16px; font-size: 14px; width: 100%;">⚙️ 設定</button>
             </div>
 
             <div id="debugButtonContainer" style="margin-top: 10px; display: none;">
-                <button onclick="toggleDebug()" style="background: #333; padding: 8px 16px; font-size: 14px; width: 100%;">デバッグ表示</button>
+                <button onclick="toggleDebug()" style="background: var(--border-main); padding: 8px 16px; font-size: 14px; width: 100%;">デバッグ表示</button>
             </div>
 
-            <div id="debug" style="margin-top: 10px; font-size: 12px; color: #aaa; text-align: left; max-height: 200px; overflow-y: auto; background: #0a0a15; padding: 12px; border-radius: 6px; word-break: break-all; display: none;">
+            <div id="debug" style="margin-top: 10px; font-size: 12px; color: var(--text-tertiary); text-align: left; max-height: 200px; overflow-y: auto; background: var(--bg-input); padding: 12px; border-radius: 6px; word-break: break-all; display: none;">
             </div>
-            <button id="sendLogsBtn" onclick="sendLogsToServer()" style="margin-top: 8px; background: #0f3460; padding: 8px 16px; font-size: 14px; width: 100%; display: none;">📤 ログをサーバーに送信</button>
+            <button id="sendLogsBtn" onclick="sendLogsToServer()" style="margin-top: 8px; background: var(--bg-section); padding: 8px 16px; font-size: 14px; width: 100%; display: none;">📤 ログをサーバーに送信</button>
         </div>
 
         <!-- AI Tab -->
@@ -979,11 +981,11 @@
         <!-- History Tab -->
         <div id="tab-history" class="tab-content">
             <div style="display: flex; align-items: center; gap: 15px; margin-bottom: 10px;">
-                <button onclick="loadHistory()" style="background: #3d405b; padding: 10px 20px; font-size: 14px;">更新</button>
+                <button onclick="loadHistory()" style="background: var(--btn-secondary); padding: 10px 20px; font-size: 14px;">更新</button>
                 <div style="flex: 1; display: flex; align-items: center; gap: 8px;">
                     <span style="font-size: 16px;">🔊</span>
                     <input type="range" id="historyVolumeSlider" min="0" max="100" value="40"
-                           style="flex: 1; height: 6px; cursor: pointer; accent-color: #60efff;"
+                           style="flex: 1; height: 6px; cursor: pointer; accent-color: var(--accent);"
                            oninput="setHistoryVolume(this.value)">
                     <span id="historyVolumeValue" style="min-width: 35px; font-size: 12px; text-align: right;">40%</span>
                 </div>
@@ -1002,7 +1004,7 @@
 
         <!-- Admin Tab -->
         <div id="tab-admin" class="tab-content">
-            <iframe id="admin-iframe" src="" style="width: 100%; height: calc(100vh - 100px); border: none; background: #0a0a15;"></iframe>
+            <iframe id="admin-iframe" src="" style="width: 100%; height: calc(100vh - 100px); border: none; background: var(--bg-input);"></iframe>
         </div>
     </div>
 
@@ -1035,18 +1037,18 @@
                 <div style="margin-bottom: 20px;">
                     <div style="margin-bottom: 10px; font-weight: 500;">表示名</div>
                     <div style="display: flex; gap: 10px; align-items: center;">
-                        <input type="text" id="displayNameInput" placeholder="名前を入力" maxlength="20" style="flex: 1; padding: 12px; background: #0a0a15; border: 1px solid #333; border-radius: 6px; color: #eee; font-size: 14px;">
-                        <button onclick="saveDisplayName()" style="padding: 12px 20px; background: #3d405b; border: none; color: #eee; border-radius: 6px; cursor: pointer;">保存</button>
+                        <input type="text" id="displayNameInput" placeholder="名前を入力" maxlength="20" style="flex: 1; padding: 12px; background: var(--bg-input); border: 1px solid var(--border-main); border-radius: 6px; color: var(--text-primary); font-size: 14px;">
+                        <button onclick="saveDisplayName()" style="padding: 12px 20px; background: var(--btn-secondary); border: none; color: var(--text-primary); border-radius: 6px; cursor: pointer;">保存</button>
                     </div>
-                    <div id="displayNameHint" style="margin-top: 10px; font-size: 12px; color: #888;">他のユーザーに表示される名前です</div>
+                    <div id="displayNameHint" style="margin-top: 10px; font-size: 12px; color: var(--text-secondary);">他のユーザーに表示される名前です</div>
                 </div>
                 <div style="margin-bottom: 20px;">
                     <div style="margin-bottom: 10px; font-weight: 500;">PTTショートカットキー</div>
                     <div style="display: flex; gap: 10px; align-items: center;">
-                        <div id="pttKeyDisplay" style="flex: 1; padding: 12px; background: #0a0a15; border-radius: 6px; text-align: center; font-family: monospace;">Ctrl+Space</div>
-                        <button onclick="startKeyRegistration()" id="registerKeyBtn" style="padding: 12px 20px; background: #3d405b; border: none; color: #eee; border-radius: 6px; cursor: pointer;">登録</button>
+                        <div id="pttKeyDisplay" style="flex: 1; padding: 12px; background: var(--bg-input); border-radius: 6px; text-align: center; font-family: monospace;">Ctrl+Space</div>
+                        <button onclick="startKeyRegistration()" id="registerKeyBtn" style="padding: 12px 20px; background: var(--btn-secondary); border: none; color: var(--text-primary); border-radius: 6px; cursor: pointer;">登録</button>
                     </div>
-                    <div id="keyRegistrationHint" style="margin-top: 10px; font-size: 12px; color: #888; display: none;">キーを押してください...</div>
+                    <div id="keyRegistrationHint" style="margin-top: 10px; font-size: 12px; color: var(--text-secondary); display: none;">キーを押してください...</div>
                 </div>
                 <div style="margin-bottom: 20px;">
                     <label style="display: flex; align-items: center; gap: 10px; cursor: pointer;">
@@ -1065,43 +1067,53 @@
                     <div style="display: flex; align-items: center; gap: 10px;">
                         <span style="font-size: 20px;">🎤</span>
                         <input type="range" id="micGainSlider" min="50" max="300" value="100"
-                               style="flex: 1; height: 8px; cursor: pointer; accent-color: #27ae60;"
+                               style="flex: 1; height: 8px; cursor: pointer; accent-color: var(--slider-mic);"
                                oninput="setMicGain(this.value)">
                         <span id="micGainValue" style="min-width: 50px; text-align: right;">1.0x</span>
                     </div>
-                    <div style="margin-top: 8px; font-size: 12px; color: #888;">送信音量を調整（0.5x〜3.0x）</div>
+                    <div style="margin-top: 8px; font-size: 12px; color: var(--text-secondary);">送信音量を調整（0.5x〜3.0x）</div>
                 </div>
                 <div style="margin-bottom: 20px;">
                     <div style="margin-bottom: 10px; font-weight: 500;">音声認識エンジン</div>
-                    <select id="speechEngineSelect" onchange="saveSpeechEngine(this.value)" style="width: 100%; padding: 12px; background: #0a0a15; border: 1px solid #333; border-radius: 6px; color: #eee; font-size: 14px; cursor: pointer;">
+                    <select id="speechEngineSelect" onchange="saveSpeechEngine(this.value)" style="width: 100%; padding: 12px; background: var(--bg-input); border: 1px solid var(--border-main); border-radius: 6px; color: var(--text-primary); font-size: 14px; cursor: pointer;">
                         <option value="webspeech">Web Speech API（高精度）</option>
                         <option value="vosk">Vosk（低遅延・安定）</option>
                     </select>
-                    <div style="margin-top: 8px; font-size: 12px; color: #888;">
+                    <div style="margin-top: 8px; font-size: 12px; color: var(--text-secondary);">
                         Web Speech API: Google音声認識（高精度、ネット必須）<br>
                         Vosk: ローカル認識（低遅延・安定、サーバー起動必須）
                     </div>
                 </div>
                 <div style="margin-bottom: 20px;">
                     <div style="margin-bottom: 10px; font-weight: 500;">AI音声</div>
-                    <select id="ttsModeSelect" onchange="saveTtsMode(this.value); toggleEdgeTtsVoiceGroup(this.value)" style="width: 100%; padding: 12px; background: #0a0a15; border: 1px solid #333; border-radius: 6px; color: #eee; font-size: 14px; cursor: pointer;">
+                    <select id="ttsModeSelect" onchange="saveTtsMode(this.value); toggleEdgeTtsVoiceGroup(this.value)" style="width: 100%; padding: 12px; background: var(--bg-input); border: 1px solid var(--border-main); border-radius: 6px; color: var(--text-primary); font-size: 14px; cursor: pointer;">
                         <option value="edge">Edge TTS（高品質・端末）</option>
                         <option value="client">端末TTS（軽量）</option>
                         <option value="none">音声なし</option>
                     </select>
                     <div id="edgeTtsVoiceGroup" style="margin-top: 8px; display: none;">
-                        <select id="edgeTtsVoiceSelect" onchange="saveEdgeTtsVoice(this.value)" style="width: 100%; padding: 10px; background: #0a0a15; border: 1px solid #333; border-radius: 6px; color: #eee; font-size: 14px; cursor: pointer;">
+                        <select id="edgeTtsVoiceSelect" onchange="saveEdgeTtsVoice(this.value)" style="width: 100%; padding: 10px; background: var(--bg-input); border: 1px solid var(--border-main); border-radius: 6px; color: var(--text-primary); font-size: 14px; cursor: pointer;">
                             <option value="ja-JP-NanamiNeural">Nanami（女性）</option>
                             <option value="ja-JP-KeitaNeural">Keita（男性）</option>
                         </select>
                     </div>
-                    <div style="margin-top: 8px; font-size: 12px; color: #888;">
+                    <div style="margin-top: 8px; font-size: 12px; color: var(--text-secondary);">
                         Edge TTS: MSニューラル音声（高品質・端末処理）<br>
                         端末TTS: ブラウザ内蔵の音声合成（軽量）
                     </div>
                 </div>
+                <div style="margin-bottom: 20px;">
+                    <div style="margin-bottom: 10px; font-weight: 500;">テーマ</div>
+                    <div class="theme-picker" id="themePicker">
+                        <div style="text-align: center;"><button class="theme-swatch" data-theme="midnight" style="--swatch: #60efff" title="Midnight"></button><div class="theme-swatch-label">Midnight</div></div>
+                        <div style="text-align: center;"><button class="theme-swatch" data-theme="teal" style="--swatch: #00B4A0" title="Teal"></button><div class="theme-swatch-label">Teal</div></div>
+                        <div style="text-align: center;"><button class="theme-swatch" data-theme="ocean" style="--swatch: #4A90D9" title="Ocean"></button><div class="theme-swatch-label">Ocean</div></div>
+                        <div style="text-align: center;"><button class="theme-swatch" data-theme="sunset" style="--swatch: #FF8A65" title="Sunset"></button><div class="theme-swatch-label">Sunset</div></div>
+                        <div style="text-align: center;"><button class="theme-swatch" data-theme="light" style="--swatch: #0097A7" title="Light"></button><div class="theme-swatch-label">Light</div></div>
+                    </div>
+                </div>
                 <div style="margin-bottom: 10px;">
-                    <button onclick="location.reload()" style="width: 100%; padding: 12px; background: #641220; border: none; color: #f8d7da; border-radius: 6px; cursor: pointer;">ページを再読み込み</button>
+                    <button onclick="location.reload()" style="width: 100%; padding: 12px; background: var(--status-error-bg); border: none; color: var(--status-error-text); border-radius: 6px; cursor: pointer;">ページを再読み込み</button>
                 </div>
             </div>
             <div class="modal-footer">
@@ -1127,6 +1139,29 @@
     <script src="js/history.js"></script>
     <script src="js/assistant.js"></script>
     <script src="js/info.js"></script>
+    <script>
+        // テーマ切り替え
+        function setTheme(name) {
+            document.documentElement.dataset.theme = name;
+            localStorage.setItem('ptt-theme', name);
+            const meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.content = getComputedStyle(document.documentElement).getPropertyValue('--bg-card').trim();
+            document.querySelectorAll('.theme-swatch').forEach(s => {
+                s.classList.toggle('active', s.dataset.theme === name);
+            });
+            // iframe（ダッシュボード等）にもテーマを反映
+            const iframe = document.getElementById('admin-iframe');
+            if (iframe && iframe.contentDocument) {
+                try { iframe.contentDocument.documentElement.dataset.theme = name; } catch(e) {}
+            }
+        }
+        document.getElementById('themePicker').addEventListener('click', e => {
+            const swatch = e.target.closest('.theme-swatch');
+            if (swatch) setTheme(swatch.dataset.theme);
+        });
+        // 初期状態のアクティブ表示
+        setTheme(localStorage.getItem('ptt-theme') || 'midnight');
+    </script>
     <script>
         // Service Worker登録
         if ('serviceWorker' in navigator) {

--- a/ptt-box/stream_client/js/assistant.js
+++ b/ptt-box/stream_client/js/assistant.js
@@ -764,10 +764,10 @@ function setupAISpeechRecognition() {
             if (statusEl) {
                 if (event.error === 'not-allowed') {
                     statusEl.textContent = 'マイク許可なし';
-                    statusEl.style.color = '#ff4757';
+                    statusEl.className = 'ai-mic-status status-color-error';
                 } else {
                     statusEl.textContent = 'エラー: ' + event.error;
-                    statusEl.style.color = '#ff4757';
+                    statusEl.className = 'ai-mic-status status-color-error';
                 }
             }
             stopAISpeechRecognition();
@@ -796,7 +796,7 @@ function setupAISpeechRecognition() {
         debugLog('AI SpeechRecognition setup error: ' + err.message);
         if (statusEl) {
             statusEl.textContent = '初期化エラー';
-            statusEl.style.color = '#ff4757';
+            statusEl.className = 'ai-mic-status status-color-error';
         }
         return false;
     }
@@ -861,7 +861,7 @@ function startAISpeechRecognition() {
         // 送信ボタンは有効のまま（押すと音声確定→送信の1ステップ操作）
         if (statusEl) {
             statusEl.textContent = '音声認識中...';
-            statusEl.style.color = '#2ed573';
+            statusEl.className = 'ai-mic-status status-color-success';
         }
         debugLog('AI voice input started');
 
@@ -888,7 +888,7 @@ function startAISpeechRecognition() {
         }
         if (statusEl) {
             statusEl.textContent = '開始エラー: ' + e.message;
-            statusEl.style.color = '#ff4757';
+            statusEl.className = 'ai-mic-status status-color-error';
         }
     }
 }
@@ -929,7 +929,7 @@ function stopAISpeechRecognition() {
     debugLog('AI voice input: ' + (aiVoiceFinalText || 'no text'));
     if (statusEl) {
         statusEl.textContent = 'タップで音声入力';
-        statusEl.style.color = '#888';
+        statusEl.className = 'ai-mic-status status-color-muted';
     }
 
     aiVoiceFinalText = '';
@@ -1012,7 +1012,7 @@ function startVoskRecognition() {
         voiceBtn.textContent = '🎤 聞き取り中...';
         if (statusEl) {
             statusEl.textContent = 'Vosk認識中...';
-            statusEl.style.color = '#2ed573';
+            statusEl.className = 'ai-mic-status status-color-success';
         }
 
         // Start capturing audio
@@ -1044,7 +1044,7 @@ function startVoskRecognition() {
         debugLog('Vosk WebSocket error');
         if (statusEl) {
             statusEl.textContent = 'Vosk接続エラー';
-            statusEl.style.color = '#ff4757';
+            statusEl.className = 'ai-mic-status status-color-error';
         }
     };
 
@@ -1099,7 +1099,7 @@ function startVoskAudioCapture() {
         var statusEl = document.getElementById('aiMicStatus');
         if (statusEl) {
             statusEl.textContent = 'マイク許可なし';
-            statusEl.style.color = '#ff4757';
+            statusEl.className = 'ai-mic-status status-color-error';
         }
         stopVoskRecognition();
     });
@@ -1168,7 +1168,7 @@ function stopVoskRecognition() {
     debugLog('Vosk voice input: ' + (aiVoiceFinalText || 'no text'));
     if (statusEl) {
         statusEl.textContent = 'タップで音声入力';
-        statusEl.style.color = '#888';
+        statusEl.className = 'ai-mic-status status-color-muted';
     }
 
     aiVoiceFinalText = '';
@@ -1201,7 +1201,7 @@ function initAIAssistant() {
         voiceBtn.textContent = '非対応';
         if (status) {
             status.textContent = '音声認識非対応';
-            status.style.color = '#ff4757';
+            status.className = 'ai-mic-status status-color-error';
         }
         debugLog('SpeechRecognition not supported');
         return;
@@ -1241,7 +1241,7 @@ function initAIAssistant() {
     // 初期状態を表示
     if (status) {
         status.textContent = 'タップで音声入力';
-        status.style.color = '#888';
+        status.className = 'ai-mic-status status-color-muted';
     }
 
     // AIタブ内の操作でWake Lockを延長

--- a/ptt-box/stream_client/js/stream.js
+++ b/ptt-box/stream_client/js/stream.js
@@ -274,7 +274,7 @@ function checkInAppBrowser() {
 function showInAppBrowserWarning(appName) {
     const warning = document.createElement('div');
     warning.id = 'inapp-warning';
-    warning.style.cssText = 'position:fixed;top:0;left:0;right:0;background:#ff6b6b;color:white;padding:15px;text-align:center;z-index:9999;font-size:14px;';
+    warning.style.cssText = 'position:fixed;top:0;left:0;right:0;background:var(--status-error-hover);color:var(--text-white);padding:15px;text-align:center;z-index:9999;font-size:14px;';
     warning.innerHTML = `
         <div style="margin-bottom:8px;"><strong>${appName}の内蔵ブラウザでは音声が再生できません</strong></div>
         <div style="font-size:12px;">右下の「︙」→「ブラウザで開く」を選択してください</div>
@@ -496,7 +496,8 @@ async function connect() {
                 const hint = document.getElementById('displayNameHint');
                 if (hint) {
                     hint.textContent = 'この名前は使用中です';
-                    hint.style.color = '#f87171';
+                    hint.className = 'status-color-error';
+                    hint.style.fontSize = '12px';
                 }
             } else if (data.type === 'logs_saved') {
                 debugLog('Logs saved: ' + data.filename + ' (' + data.lineCount + ' lines)');
@@ -1538,10 +1539,12 @@ function saveDisplayName() {
         const hint = document.getElementById('displayNameHint');
         if (hint) {
             hint.textContent = '保存しました';
-            hint.style.color = '#4ade80';
+            hint.className = 'status-color-success';
+            hint.style.fontSize = '12px';
             setTimeout(() => {
                 hint.textContent = '他のユーザーに表示される名前です';
-                hint.style.color = '#888';
+                hint.className = 'status-color-muted';
+                hint.style.fontSize = '12px';
             }, 2000);
         }
         debugLog('Display name saved: ' + name);

--- a/ptt-box/stream_client/monitor.html
+++ b/ptt-box/stream_client/monitor.html
@@ -1,9 +1,11 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <script>document.documentElement.dataset.theme = localStorage.getItem('ptt-theme') || 'midnight';</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PTTモニター</title>
+    <link rel="stylesheet" href="themes.css">
     <style>
         * {
             box-sizing: border-box;
@@ -13,11 +15,11 @@
             max-width: 800px;
             margin: 0 auto;
             padding: 20px;
-            background: #1a1a2e;
-            color: #eee;
+            background: var(--bg-page);
+            color: var(--text-primary);
         }
         .container {
-            background: #16213e;
+            background: var(--bg-card);
             border-radius: 12px;
             padding: 20px;
         }
@@ -27,7 +29,7 @@
             align-items: center;
             margin-bottom: 20px;
             padding-bottom: 15px;
-            border-bottom: 1px solid #0f3460;
+            border-bottom: 1px solid var(--bg-section);
         }
         h1 {
             margin: 0;
@@ -47,7 +49,7 @@
         .volume-control input[type="range"] {
             width: 80px;
             cursor: pointer;
-            accent-color: #60efff;
+            accent-color: var(--accent);
         }
         #volumeValue {
             min-width: 40px;
@@ -60,21 +62,21 @@
             font-weight: 500;
         }
         .status-badge.connected {
-            background: #1b4332;
-            color: #95d5b2;
+            background: var(--status-success-bg);
+            color: var(--status-success-soft);
         }
         .status-badge.disconnected {
-            background: #641220;
-            color: #f8d7da;
+            background: var(--status-error-bg);
+            color: var(--status-error-text);
         }
         .status-badge.connecting {
-            background: #3d405b;
-            color: #f4f1de;
+            background: var(--btn-secondary);
+            color: var(--status-neutral);
         }
 
         /* PTT Status Section */
         .ptt-section {
-            background: #0f3460;
+            background: var(--bg-section);
             border-radius: 8px;
             padding: 15px;
             margin-bottom: 20px;
@@ -94,13 +96,13 @@
             width: 12px;
             height: 12px;
             border-radius: 50%;
-            background: #666;
+            background: var(--text-muted);
         }
         .ptt-indicator.idle {
-            background: #666;
+            background: var(--text-muted);
         }
         .ptt-indicator.transmitting {
-            background: #e94560;
+            background: var(--status-error);
             animation: pulse 1s infinite;
         }
         @keyframes pulse {
@@ -113,17 +115,17 @@
         }
         .ptt-timer {
             font-size: 0.9em;
-            color: #aaa;
+            color: var(--text-tertiary);
         }
         .ptt-progress {
             height: 6px;
-            background: #1a1a2e;
+            background: var(--bg-page);
             border-radius: 3px;
             overflow: hidden;
         }
         .ptt-progress-bar {
             height: 100%;
-            background: linear-gradient(90deg, #60efff, #e94560);
+            background: linear-gradient(90deg, var(--gradient-progress-start), var(--gradient-progress-end));
             width: 0%;
             transition: width 0.5s;
         }
@@ -141,14 +143,14 @@
         .section-title {
             font-size: 1em;
             font-weight: 500;
-            color: #aaa;
+            color: var(--text-tertiary);
         }
         .client-count {
             font-size: 0.9em;
-            color: #60efff;
+            color: var(--accent);
         }
         .client-list {
-            background: #0f3460;
+            background: var(--bg-section);
             border-radius: 8px;
             overflow: hidden;
         }
@@ -156,7 +158,7 @@
             display: flex;
             align-items: center;
             padding: 12px 15px;
-            border-bottom: 1px solid #1a1a2e;
+            border-bottom: 1px solid var(--bg-page);
             gap: 12px;
         }
         .client-item:last-child {
@@ -169,13 +171,13 @@
             flex-shrink: 0;
         }
         .client-status-dot.connected {
-            background: #95d5b2;
+            background: var(--status-success-soft);
         }
         .client-status-dot.connecting {
-            background: #f4f1de;
+            background: var(--status-neutral);
         }
         .client-status-dot.failed {
-            background: #e94560;
+            background: var(--status-error);
         }
         .client-info {
             flex: 1;
@@ -185,28 +187,28 @@
         }
         .client-details {
             font-size: 0.8em;
-            color: #888;
+            color: var(--text-secondary);
             margin-top: 2px;
         }
         .client-ice {
             font-size: 0.75em;
             padding: 2px 8px;
             border-radius: 4px;
-            background: #1a1a2e;
+            background: var(--bg-page);
         }
         .client-ice.connected {
-            color: #95d5b2;
+            color: var(--status-success-soft);
         }
         .client-ice.checking {
-            color: #f4f1de;
+            color: var(--status-neutral);
         }
         .client-ice.failed {
-            color: #e94560;
+            color: var(--status-error);
         }
         .no-clients {
             padding: 30px;
             text-align: center;
-            color: #666;
+            color: var(--text-muted);
         }
 
         /* Stats Section */
@@ -217,7 +219,7 @@
             margin-bottom: 20px;
         }
         .stat-card {
-            background: #0f3460;
+            background: var(--bg-section);
             border-radius: 8px;
             padding: 12px;
             text-align: center;
@@ -225,11 +227,11 @@
         .stat-value {
             font-size: 1.5em;
             font-weight: 600;
-            color: #60efff;
+            color: var(--accent);
         }
         .stat-label {
             font-size: 0.75em;
-            color: #888;
+            color: var(--text-secondary);
             margin-top: 4px;
         }
 
@@ -238,9 +240,9 @@
             margin-top: 15px;
         }
         .debug-toggle {
-            background: #333;
+            background: var(--border-main);
             border: none;
-            color: #aaa;
+            color: var(--text-tertiary);
             padding: 8px 16px;
             font-size: 12px;
             border-radius: 6px;
@@ -248,16 +250,16 @@
             width: 100%;
         }
         .debug-toggle:hover {
-            background: #444;
+            background: var(--border-medium);
         }
         .debug-log {
             margin-top: 10px;
             font-size: 11px;
-            color: #888;
+            color: var(--text-secondary);
             text-align: left;
             max-height: 200px;
             overflow-y: auto;
-            background: #0a0a15;
+            background: var(--bg-input);
             padding: 12px;
             border-radius: 6px;
             font-family: monospace;

--- a/ptt-box/stream_client/sw.js
+++ b/ptt-box/stream_client/sw.js
@@ -1,9 +1,10 @@
 // Service Worker for Webトランシーバー PWA
 
-const CACHE_NAME = 'ptt-cache-v2';
+const CACHE_NAME = 'ptt-cache-v3';
 const ASSETS_TO_CACHE = [
     '/',
     '/index.html',
+    '/themes.css',
     '/js/stream.js',
     '/js/history.js',
     '/js/info.js',

--- a/ptt-box/stream_client/themes.css
+++ b/ptt-box/stream_client/themes.css
@@ -60,11 +60,19 @@
     /* ボタン */
     --btn-secondary: #3d405b;
     --btn-secondary-hover: #5c5f7e;
+    --btn-secondary-border: transparent;
+    --btn-secondary-text: inherit;
     --btn-disabled: #555;
     --btn-voice: #4a4a6a;
     --btn-voice-hover: #5a5a7a;
     --btn-stop: #ff6b6b;
     --btn-stop-hover: #ee5a5a;
+    --btn-danger-bg: var(--status-error);
+    --btn-danger-border: transparent;
+    --btn-danger-text: var(--text-primary);
+    --btn-warning-bg: var(--status-warning);
+    --btn-warning-border: transparent;
+    --btn-warning-text: #000;
 
     /* チャット */
     --chat-user-bg: #1e3a5f;
@@ -173,11 +181,13 @@
     --border-medium: #ccc;
     --border-light: #bbb;
 
-    --btn-secondary: #e0e0e0;
-    --btn-secondary-hover: #d0d0d0;
+    --btn-secondary: rgba(0, 151, 167, 0.12);
+    --btn-secondary-hover: rgba(0, 151, 167, 0.22);
+    --btn-secondary-border: rgba(0, 151, 167, 0.3);
+    --btn-secondary-text: #0097A7;
     --btn-disabled: #ccc;
-    --btn-voice: #d8d8e8;
-    --btn-voice-hover: #c8c8d8;
+    --btn-voice: rgba(0, 151, 167, 0.12);
+    --btn-voice-hover: rgba(0, 151, 167, 0.22);
     --btn-stop: #ef5350;
     --btn-stop-hover: #e53935;
 
@@ -209,6 +219,13 @@
     --status-blocked-bg: #f3e5f5;
     --status-blocked-text: #7b1fa2;
     --status-warning-bg: #fff8e1;
+
+    --btn-danger-bg: rgba(233, 69, 96, 0.12);
+    --btn-danger-border: rgba(233, 69, 96, 0.3);
+    --btn-danger-text: #c62828;
+    --btn-warning-bg: rgba(245, 166, 35, 0.15);
+    --btn-warning-border: rgba(245, 166, 35, 0.3);
+    --btn-warning-text: #e65100;
 }
 
 /* ==========================================================================

--- a/ptt-box/stream_client/themes.css
+++ b/ptt-box/stream_client/themes.css
@@ -1,0 +1,249 @@
+/* ==========================================================================
+   PTT Web Transceiver - Color Theme System
+   CSS変数によるカラーテーマ管理
+   ========================================================================== */
+
+:root, [data-theme="midnight"] {
+    /* 背景 */
+    --bg-page: #1a1a2e;
+    --bg-card: #16213e;
+    --bg-section: #0f3460;
+    --bg-input: #0a0a15;
+    --bg-chat: #0f0f23;
+    --bg-meter: #0a1628;
+    --bg-hover: #1a4a7a;
+
+    /* アクセント */
+    --accent: #60efff;
+    --accent-hover: #4dd9e6;
+    --accent-ai: #00d9ff;
+    --accent-ai-hover: #00b8d9;
+    --accent-on-accent: #000;          /* アクセント背景上のテキスト */
+    --accent-on-accent-dark: #1a1a2e;  /* アクセント背景上のテキスト（濃色） */
+
+    /* ステータス — 全ダークテーマ共通 */
+    --status-error: #e94560;
+    --status-error-hover: #ff6b6b;
+    --status-error-bg: #641220;
+    --status-error-text: #f8d7da;
+    --status-error-hint: #f87171;
+    --status-success: #4ade80;
+    --status-success-soft: #95d5b2;
+    --status-success-bg: #1b4332;
+    --status-success-bright: #2ed573;
+    --status-success-border-dim: #1a8a4e;
+    --status-warning: #f5a623;
+    --status-warning-bg: #5c4d1a;
+    --status-service-up: #4caf50;
+    --status-service-down: #f44336;
+    --status-service-unknown: #9e9e9e;
+    --status-blocked-bg: #4a1942;
+    --status-blocked-text: #e8b4d8;
+    --status-neutral: #f4f1de;
+
+    /* テキスト */
+    --text-primary: #eee;
+    --text-secondary: #888;
+    --text-tertiary: #aaa;
+    --text-muted: #666;
+    --text-light: #ccc;
+    --text-dim: #bbb;
+    --text-white: #fff;
+    --text-dark: #000;
+    --text-streaming: #ddd;
+
+    /* ボーダー */
+    --border-main: #333;
+    --border-medium: #444;
+    --border-light: #555;
+
+    /* ボタン */
+    --btn-secondary: #3d405b;
+    --btn-secondary-hover: #5c5f7e;
+    --btn-disabled: #555;
+    --btn-voice: #4a4a6a;
+    --btn-voice-hover: #5a5a7a;
+    --btn-stop: #ff6b6b;
+    --btn-stop-hover: #ee5a5a;
+
+    /* チャット */
+    --chat-user-bg: #1e3a5f;
+    --chat-ai-bg: #16213e;
+    --chat-divider: #2a2a3a;
+
+    /* 半透明 */
+    --accent-alpha-10: rgba(96, 239, 255, 0.1);
+    --status-error-alpha-50: rgba(233, 69, 96, 0.5);
+    --status-success-alpha-50: rgba(149, 213, 178, 0.5);
+    --service-error-alpha-20: rgba(244, 67, 54, 0.2);
+    --overlay-dark: rgba(0, 0, 0, 0.8);
+    --overlay-medium: rgba(0, 0, 0, 0.5);
+    --shadow-popup: rgba(0, 0, 0, 0.5);
+    --shadow-toast: rgba(0, 0, 0, 0.4);
+    --toast-bg: rgba(22, 33, 62, 0.92);
+    --toast-border: rgba(255, 255, 255, 0.1);
+    --table-hover: rgba(255, 255, 255, 0.05);
+
+    /* グラデーション */
+    --gradient-volume-start: #00ff87;
+    --gradient-volume-end: #60efff;
+    --gradient-progress-start: #60efff;
+    --gradient-progress-end: #e94560;
+
+    /* スライダー */
+    --slider-p2p: #f39c12;
+    --slider-mic: #27ae60;
+}
+
+/* ==========================================================================
+   Teal Theme — 落ち着いた青緑アクセント
+   ========================================================================== */
+[data-theme="teal"] {
+    --accent: #00B4A0;
+    --accent-hover: #009E8C;
+    --accent-ai: #00C9B2;
+    --accent-ai-hover: #00A896;
+    --accent-on-accent: #fff;
+    --accent-on-accent-dark: #fff;
+    --accent-alpha-10: rgba(0, 180, 160, 0.1);
+    --gradient-volume-end: #00B4A0;
+    --gradient-progress-start: #00B4A0;
+}
+
+/* ==========================================================================
+   Ocean Theme — クールな深海ブルー
+   ========================================================================== */
+[data-theme="ocean"] {
+    --accent: #4A90D9;
+    --accent-hover: #3A7BC8;
+    --accent-ai: #5BA0E9;
+    --accent-ai-hover: #4A90D9;
+    --accent-on-accent: #fff;
+    --accent-on-accent-dark: #fff;
+    --accent-alpha-10: rgba(74, 144, 217, 0.1);
+    --gradient-volume-end: #4A90D9;
+    --gradient-progress-start: #4A90D9;
+}
+
+/* ==========================================================================
+   Sunset Theme — 暖かいオレンジアクセント
+   ========================================================================== */
+[data-theme="sunset"] {
+    --accent: #FF8A65;
+    --accent-hover: #FF7043;
+    --accent-ai: #FFA280;
+    --accent-ai-hover: #FF8A65;
+    --accent-on-accent: #1a1a2e;
+    --accent-on-accent-dark: #1a1a2e;
+    --accent-alpha-10: rgba(255, 138, 101, 0.1);
+    --gradient-volume-end: #FF8A65;
+    --gradient-progress-start: #FF8A65;
+}
+
+/* ==========================================================================
+   Light Theme — 明るい背景
+   ========================================================================== */
+[data-theme="light"] {
+    --bg-page: #f0f2f5;
+    --bg-card: #ffffff;
+    --bg-section: #e8edf2;
+    --bg-input: #f5f5f5;
+    --bg-chat: #fafafa;
+    --bg-meter: #e0e0e0;
+    --bg-hover: #dce4ed;
+
+    --accent: #0097A7;
+    --accent-hover: #00838F;
+    --accent-ai: #00ACC1;
+    --accent-ai-hover: #0097A7;
+    --accent-on-accent: #fff;
+    --accent-on-accent-dark: #fff;
+
+    --text-primary: #222;
+    --text-secondary: #666;
+    --text-tertiary: #777;
+    --text-muted: #999;
+    --text-light: #555;
+    --text-dim: #777;
+    --text-white: #fff;
+    --text-dark: #fff;
+    --text-streaming: #333;
+
+    --border-main: #ddd;
+    --border-medium: #ccc;
+    --border-light: #bbb;
+
+    --btn-secondary: #e0e0e0;
+    --btn-secondary-hover: #d0d0d0;
+    --btn-disabled: #ccc;
+    --btn-voice: #d8d8e8;
+    --btn-voice-hover: #c8c8d8;
+    --btn-stop: #ef5350;
+    --btn-stop-hover: #e53935;
+
+    --chat-user-bg: #e3f0fc;
+    --chat-ai-bg: #f5f5f5;
+    --chat-divider: #e0e0e0;
+
+    --accent-alpha-10: rgba(0, 151, 167, 0.1);
+    --status-error-alpha-50: rgba(233, 69, 96, 0.4);
+    --status-success-alpha-50: rgba(76, 175, 80, 0.4);
+    --service-error-alpha-20: rgba(244, 67, 54, 0.1);
+    --overlay-dark: rgba(0, 0, 0, 0.5);
+    --overlay-medium: rgba(0, 0, 0, 0.3);
+    --shadow-popup: rgba(0, 0, 0, 0.2);
+    --shadow-toast: rgba(0, 0, 0, 0.15);
+    --toast-bg: rgba(255, 255, 255, 0.95);
+    --toast-border: rgba(0, 0, 0, 0.1);
+    --table-hover: rgba(0, 0, 0, 0.03);
+
+    --gradient-volume-start: #4CAF50;
+    --gradient-volume-end: #0097A7;
+    --gradient-progress-start: #0097A7;
+    --gradient-progress-end: #e94560;
+
+    --status-error-bg: #fce4ec;
+    --status-error-text: #c62828;
+    --status-success-bg: #e8f5e9;
+    --status-neutral: #555;
+    --status-blocked-bg: #f3e5f5;
+    --status-blocked-text: #7b1fa2;
+    --status-warning-bg: #fff8e1;
+}
+
+/* ==========================================================================
+   Theme Picker UI
+   ========================================================================== */
+.theme-picker {
+    display: flex;
+    gap: 12px;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+.theme-swatch {
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--swatch);
+    border: 3px solid transparent;
+    cursor: pointer;
+    transition: border-color 0.2s, transform 0.15s;
+    padding: 0;
+}
+.theme-swatch:hover {
+    transform: scale(1.1);
+}
+.theme-swatch.active {
+    border-color: var(--text-primary);
+}
+.theme-swatch-label {
+    font-size: 10px;
+    color: var(--text-secondary);
+    text-align: center;
+    margin-top: 4px;
+}
+
+/* ステータスカラーのユーティリティクラス（JS動的切替用） */
+.status-color-error   { color: var(--status-error) !important; }
+.status-color-success { color: var(--status-success-bright) !important; }
+.status-color-muted   { color: var(--text-secondary) !important; }


### PR DESCRIPTION
## Summary
- 134箇所以上の直書き色をCSS変数に抽出し、`themes.css`で一元管理
- 5テーマ対応: Midnight（デフォルト）、Teal、Ocean、Sunset、Light
- 設定モーダルにテーマセレクタUI追加（色付き丸ボタン）
- localStorage保存、FOUC防止、iframe（ダッシュボード）連動
- JS動的カラーをCSSクラス切替に移行
- Lightテーマのボタン視認性改善（アクセント色ボーダー+テキスト）

## Test plan
- [x] 全60テストパス
- [x] Midnightテーマで見た目変更なし確認
- [x] 5テーマ切り替え動作確認
- [x] Lightテーマのボタン・入力欄の視認性確認
- [x] ダッシュボード（iframe）へのテーマ反映確認
- [x] テーマ選択のlocalStorage保存・復元確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)