### PR TITLE
feat: 設定モーダルに音量スライダー追加 & 最小モードレイアウト改善

### DIFF
--- a/ptt-box/stream_client/index.html
+++ b/ptt-box/stream_client/index.html
@@ -956,7 +956,7 @@
                     <span class="connection-indicator"></span>
                     <span class="minimal-conn-text">未接続</span>
                 </button>
-                <div id="minimalSpeakerStatus" style="flex: 1; text-align: center; font-size: 13px;">待機中</div>
+                <div id="minimalSpeakerStatus" style="flex: 1; text-align: left; margin-left: 10px; font-size: 13px;">待機中</div>
                 <button class="minimal-settings-btn" onclick="openSettings()">⚙️</button>
             </div>
 
@@ -1144,6 +1144,23 @@
                         <input type="checkbox" id="debugButtonToggle" onchange="toggleDebugButtonVisibility(this.checked)" style="width: 18px; height: 18px; cursor: pointer;">
                         <span>デバッグボタンを表示</span>
                     </label>
+                </div>
+                <div style="margin-bottom: 20px;">
+                    <div style="margin-bottom: 10px; font-weight: 500;">音量</div>
+                    <div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
+                        <span style="font-size: 16px;" title="PCストリーム">🔈</span>
+                        <input type="range" id="settingsVolumeSlider" min="0" max="100" value="40"
+                               style="flex: 1; height: 8px; cursor: pointer; accent-color: var(--accent);"
+                               oninput="setVolume(this.value); document.getElementById('volumeSlider').value=this.value; document.getElementById('settingsVolumeValue').textContent=this.value+'%';">
+                        <span id="settingsVolumeValue" style="min-width: 40px; text-align: right; font-size: 13px;">40%</span>
+                    </div>
+                    <div style="display: flex; align-items: center; gap: 10px;">
+                        <span style="font-size: 16px;" title="P2P音声">👥</span>
+                        <input type="range" id="settingsP2pVolumeSlider" min="0" max="100" value="40"
+                               style="flex: 1; height: 8px; cursor: pointer; accent-color: var(--slider-p2p);"
+                               oninput="setP2PVolume(this.value); document.getElementById('p2pVolumeSlider').value=this.value; document.getElementById('settingsP2pVolumeValue').textContent=this.value+'%';">
+                        <span id="settingsP2pVolumeValue" style="min-width: 40px; text-align: right; font-size: 13px;">40%</span>
+                    </div>
                 </div>
                 <div style="margin-bottom: 20px;">
                     <div style="margin-bottom: 10px; font-weight: 500;">マイクゲイン</div>

--- a/ptt-box/stream_client/js/stream.js
+++ b/ptt-box/stream_client/js/stream.js
@@ -1449,6 +1449,13 @@ function openSettings() {
         loadTtsModeToSelect();
         loadEdgeTtsVoice();
         loadSpeechEngineToSelect();
+        // 音量スライダーを同期
+        const vol = document.getElementById('volumeSlider');
+        const p2pVol = document.getElementById('p2pVolumeSlider');
+        const sVol = document.getElementById('settingsVolumeSlider');
+        const sP2p = document.getElementById('settingsP2pVolumeSlider');
+        if (vol && sVol) { sVol.value = vol.value; document.getElementById('settingsVolumeValue').textContent = vol.value + '%'; }
+        if (p2pVol && sP2p) { sP2p.value = p2pVol.value; document.getElementById('settingsP2pVolumeValue').textContent = p2pVol.value + '%'; }
     }
 }
 


### PR DESCRIPTION
## Summary
- 設定モーダルにPC/P2P音量スライダーを追加（マイクゲインの上）
- 最小モードでも音量調整が可能に（通常モードに戻る手間を解消）
- モーダル開閉時にスライダー値を自動同期
- 最小ヘッダーの状態テキストを左寄せ+マージンで安定感向上

## Test plan
- [x] 全60テストパス
- [x] 設定モーダルの音量スライダーが現在値を反映
- [x] スライダー操作でメイン画面と連動
- [x] 最小モードの状態テキスト左寄せ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)